### PR TITLE
security + JWT 를 사용한 인증/인가 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/JwtFilter.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/JwtFilter.java
@@ -1,0 +1,57 @@
+package com.avg.lawsuitmanagement.common.config;
+
+import com.avg.lawsuitmanagement.token.provider.TokenProvider;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer";
+    private final TokenProvider tokenProvider;
+
+    // 실제 필터링 로직은 doFilterInternal 에 들어감
+    // JWT 토큰의 인증 정보를 현재 쓰레드의 SecurityContext 에 저장하는 역할 수행
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws IOException, ServletException {
+
+        // 1. Request Header 에서 토큰을 꺼냄
+        String jwt = resolveToken(request);
+
+        //2. 토큰 유효성 검사
+
+        if (jwt == null || !tokenProvider.validateToken(jwt)) {
+
+            log.error("AUTHORIZATION을 잘못 보냈습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+// 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
+        Authentication authentication = tokenProvider.getAuthentication(jwt);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    // Request Header 에서 토큰 정보를 꺼내오기
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+
+        return bearerToken.split(" ")[1]; //[0] 은 "bearer"
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -37,6 +38,12 @@ public class SecurityConfig {
             .and()
             .authorizeRequests()
             .antMatchers("/token/**").permitAll() //열어줄 요청들 표기
+
+            //for test
+            //테스트 메소드는 admin 권한이 있어야 가능
+            .antMatchers("/test/**")
+            .hasAnyRole("ADMIN")
+
             .anyRequest().authenticated() //나머지 요청은 인증 필요
 
             .and()
@@ -44,7 +51,8 @@ public class SecurityConfig {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
             .and()
-//            .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(new JwtFilter(tokenProvider),
+                UsernamePasswordAuthenticationFilter.class)
             .build();
     }
 

--- a/src/main/java/com/avg/lawsuitmanagement/token/controller/TestController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/controller/TestController.java
@@ -1,0 +1,19 @@
+package com.avg.lawsuitmanagement.token.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class TestController {
+
+    @GetMapping("/test")
+    public void testMethod() {
+
+        System.out.println("테스트 성공");
+    }
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/token/dto/RefreshTokenDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/dto/RefreshTokenDto.java
@@ -1,0 +1,15 @@
+package com.avg.lawsuitmanagement.token.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@ToString
+public class RefreshTokenDto {
+    private String key; //이메일
+    private String value; // refreshToken
+}

--- a/src/main/java/com/avg/lawsuitmanagement/token/provider/TokenProvider.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/provider/TokenProvider.java
@@ -2,20 +2,30 @@ package com.avg.lawsuitmanagement.token.provider;
 
 
 import com.avg.lawsuitmanagement.token.dto.JwtTokenDto;
+import com.avg.lawsuitmanagement.token.dto.MemberDto;
+import com.avg.lawsuitmanagement.token.service.CustomUserDetail;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class TokenProvider {
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 10; //10초
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 5; //5분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60; //60분
     private final Key key; //토큰 암호화에 사용되는 비밀키
 
@@ -46,10 +56,57 @@ public class TokenProvider {
             .build();
     }
 
+    /*
+    토큰이 적법한지 검증한다.
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            log.info(e.getMessage());
+        }
+        return false;
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+
+//        String[] authorityArr = claims.get("auth").toString().split(",");
+//        List<GrantedAuthority> authorityList = new ArrayList<>();
+//        for(String auth : authorityArr) {
+//            authorityList.add(new SimpleGrantedAuthority(auth));
+//        }
+
+        List<GrantedAuthority> authorityList =
+            Arrays.stream(claims.get("auth").toString().split(","))
+                .map((String authority) -> new SimpleGrantedAuthority(authority))
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 리턴
+
+        MemberDto memberDto = MemberDto.builder()
+            .name(claims.getSubject())
+            .build();
+
+        CustomUserDetail customUserDetail = new CustomUserDetail(memberDto);
+
+        return new UsernamePasswordAuthenticationToken(customUserDetail, "", authorityList);
+    }
+
+
     //AccessToken 발행
     private String createAccessToken(long now, Authentication authentication) {
 
-        //해당 유저의 권한 목록 ex) ROLE_ADMIN, ROLE_CUSTOMER
+        //해당 유저의 권한 목록 ex) ROLE_ADMIN, ROLE_EMPLOYEE
+
         String authorities = authentication.getAuthorities().stream()
             .map((GrantedAuthority grantedAuthority) -> grantedAuthority.getAuthority())
             .collect(Collectors.joining(","));
@@ -68,5 +125,10 @@ public class TokenProvider {
             .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
             .signWith(key, SignatureAlgorithm.HS256)
             .compact();
+    }
+
+    private Claims parseClaims(String accessToken) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken)
+            .getBody();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/token/repository/TokenMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/repository/TokenMapperRepository.java
@@ -2,6 +2,8 @@ package com.avg.lawsuitmanagement.token.repository;
 
 
 import com.avg.lawsuitmanagement.token.dto.MemberDto;
+import com.avg.lawsuitmanagement.token.dto.RefreshTokenDto;
+import com.avg.lawsuitmanagement.token.repository.param.RefreshTokenParam;
 import com.avg.lawsuitmanagement.token.repository.param.SignUpParam;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -10,4 +12,6 @@ public interface TokenMapperRepository {
 
     MemberDto selectMemberByEmail(String email);
     void insertMember(SignUpParam param);
+    void insertRefreshToken(RefreshTokenParam param);
+    RefreshTokenDto selectRefreshTokenByKey(String key);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/token/repository/param/RefreshTokenParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/repository/param/RefreshTokenParam.java
@@ -1,0 +1,13 @@
+package com.avg.lawsuitmanagement.token.repository.param;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class RefreshTokenParam {
+    private String key;
+    private String value;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/token/service/TokenService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/service/TokenService.java
@@ -3,6 +3,8 @@ package com.avg.lawsuitmanagement.token.service;
 import com.avg.lawsuitmanagement.token.controller.form.LoginForm;
 import com.avg.lawsuitmanagement.token.dto.JwtTokenDto;
 import com.avg.lawsuitmanagement.token.provider.TokenProvider;
+import com.avg.lawsuitmanagement.token.repository.TokenMapperRepository;
+import com.avg.lawsuitmanagement.token.repository.param.RefreshTokenParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,6 +19,8 @@ public class TokenService {
 
     private final TokenProvider tokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    private final TokenMapperRepository tokenMapperRepository;
 
 
     public JwtTokenDto login(LoginForm form) {
@@ -33,7 +37,12 @@ public class TokenService {
         //무사히 통과했다면 jwt 토큰 발행
         JwtTokenDto jwtTokenDto = tokenProvider.createTokenDto(authentication);
 
-        //refreshToken DB에 저장 구현 예정
+        //refreshToken DB에 저장
+        tokenMapperRepository.insertRefreshToken(RefreshTokenParam.builder()
+            .key(form.getEmail())
+            .value(jwtTokenDto.getRefreshToken())
+            .build());
+
         return jwtTokenDto;
     }
 

--- a/src/main/resources/mybatis/mapper/Token.xml
+++ b/src/main/resources/mybatis/mapper/Token.xml
@@ -6,7 +6,7 @@
 <mapper namespace="com.avg.lawsuitmanagement.token.repository.TokenMapperRepository">
 
     <select id="selectMemberByEmail" parameterType="java.lang.String">
-        select m.*, h.name as hierarchy_id, r.name as role_id
+        select m.*, h.name as hierarchy, r.name as role
         from member m
                  join hierarchy h on m.hierarchy_id = h.id
                  join role r on m.role_id = r.id

--- a/src/main/resources/mybatis/mapper/Token.xml
+++ b/src/main/resources/mybatis/mapper/Token.xml
@@ -20,9 +20,10 @@
     </insert>
 
     <insert id="insertRefreshToken" parameterType="RefreshTokenParam">
-        insert into refresh_token (`key`, `value`)
+        replace into refresh_token (`key`, `value`)
         values (#{key}, #{value})
     </insert>
+
 
     <select id="selectRefreshTokenByKey" parameterType="java.lang.String">
         select *

--- a/src/main/resources/mybatis/mapper/Token.xml
+++ b/src/main/resources/mybatis/mapper/Token.xml
@@ -5,16 +5,28 @@
 
 <mapper namespace="com.avg.lawsuitmanagement.token.repository.TokenMapperRepository">
 
-    <select id = "selectMemberByEmail" parameterType="java.lang.String">
+    <select id="selectMemberByEmail" parameterType="java.lang.String">
         select m.*, h.name as hierarchy_id, r.name as role_id
         from member m
-                join hierarchy h on m.hierarchy_id = h.id
-                join role r on m.role_id = r.id
-        where m.email = #{email} and m.is_deleted = false
+                 join hierarchy h on m.hierarchy_id = h.id
+                 join role r on m.role_id = r.id
+        where m.email = #{email}
+          and m.is_deleted = false
     </select>
 
     <insert id="insertMember" parameterType="SignUpParam">
         insert into member (email, password, name, phone, hierarchy_id, address, role_id)
         values (#{email}, #{password}, #{name}, #{phone}, #{hierarchyId}, #{address}, #{roleId})
     </insert>
+
+    <insert id="insertRefreshToken" parameterType="RefreshTokenParam">
+        insert into refresh_token (`key`, `value`)
+        values (#{key}, #{value})
+    </insert>
+
+    <select id="selectRefreshTokenByKey" parameterType="java.lang.String">
+        select *
+        from refresh_token
+        where `key` = #{key}
+    </select>
 </mapper>

--- a/src/test/java/com/avg/lawsuitmanagement/token/TokenTest.java
+++ b/src/test/java/com/avg/lawsuitmanagement/token/TokenTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.avg.lawsuitmanagement.token.controller.form.LoginForm;
 import com.avg.lawsuitmanagement.token.dto.JwtTokenDto;
+import com.avg.lawsuitmanagement.token.dto.RefreshTokenDto;
 import com.avg.lawsuitmanagement.token.repository.TokenMapperRepository;
 import com.avg.lawsuitmanagement.token.repository.param.SignUpParam;
 import com.avg.lawsuitmanagement.token.service.TokenService;
@@ -58,7 +59,11 @@ public class TokenTest {
 
         //then
         assertNotNull(tokenDto);
-        System.out.println(tokenDto);
+
+        RefreshTokenDto refreshTokenDto = tokenMapperRepository.selectRefreshTokenByKey(email);
+
+        System.out.println("발급 토큰 : " + tokenDto);
+        System.out.println("저장된 refresh 토큰 : " + refreshTokenDto);
     }
 
     @Test


### PR DESCRIPTION
Background
---
로그인, 회원가입을 제외한 모든 http request는, 컨트롤러에 도달하기 전 jwtFilter를 통해 인증/인가 과정을 거쳐야 한다.
인증 : request의 헤더에 포함되어야 하는 토큰이 정해진 sign key, 정해진 암호화 방식으로 암호화되었으면 통과
인가 : securityConfig에 정해진 규칙에 따라, 요청 별로 적법한 권한이 있는지 확인하는 것
예를 들어 테스트로 작성된 "/test" get method는 admin 권한이 있어야 인가 된다.

Change
---
헤더에 올바른 accesstoken을 담아 request 할 경우, jwt filter에서 인증/인가 과정을 거친다. 실질적인 인증/인가는 TokenProvider 클래스에서 이루어진다. 

Test
---
postman을 통한 테스트 완료

Analatics
---
차후 예외처리 체계가 갖춰지면, 좀 더 세밀한 예외처리가 필요할 듯 하다.

Plan
---
refresh 토큰을 통한 access 토큰 재발급 구현