### PR TITLE
Exception

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.avg.lawsuitmanagement.common.config;
 
 
-import com.avg.lawsuitmanagement.common.exception.CustomAuthenticationEntryPoint;
 import com.avg.lawsuitmanagement.token.provider.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -23,7 +22,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
-    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+//    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -44,7 +43,7 @@ public class SecurityConfig {
             //for test
             //테스트 메소드는 admin 권한이 있어야 가능
             .antMatchers("/test/**")
-            .hasAnyRole("ADMIN", "EMPLOYEE")
+            .hasAnyRole("ADMIN")
 
             .anyRequest().authenticated() //나머지 요청은 인증 필요
 
@@ -53,9 +52,9 @@ public class SecurityConfig {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
             //인증 간 예외처리
-            .and()
-            .exceptionHandling()
-            .authenticationEntryPoint(customAuthenticationEntryPoint)
+//            .and()
+//            .exceptionHandling()
+//            .authenticationEntryPoint(customAuthenticationEntryPoint)
 
             .and()
             .addFilterBefore(new JwtFilter(tokenProvider),

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.common.config;
 
 
+import com.avg.lawsuitmanagement.common.exception.CustomAuthenticationEntryPoint;
 import com.avg.lawsuitmanagement.token.provider.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -42,13 +44,18 @@ public class SecurityConfig {
             //for test
             //테스트 메소드는 admin 권한이 있어야 가능
             .antMatchers("/test/**")
-            .hasAnyRole("ADMIN")
+            .hasAnyRole("ADMIN", "EMPLOYEE")
 
             .anyRequest().authenticated() //나머지 요청은 인증 필요
 
             .and()
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+            //인증 간 예외처리
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
 
             .and()
             .addFilterBefore(new JwtFilter(tokenProvider),

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/CustomRuntimeException.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/CustomRuntimeException.java
@@ -1,0 +1,12 @@
+package com.avg.lawsuitmanagement.common.exception;
+
+import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomRuntimeException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/dto/ExceptionDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/dto/ExceptionDto.java
@@ -1,0 +1,14 @@
+package com.avg.lawsuitmanagement.common.exception.dto;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@RequiredArgsConstructor
+public class ExceptionDto {
+    private String code;
+    private String message;
+
+
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.avg.lawsuitmanagement.common.exception.handler;
+
+import com.avg.lawsuitmanagement.common.exception.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.exception.dto.ExceptionDto;
+import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 모든 정의된 business exception에 대한 처리
+     */
+    @ExceptionHandler(CustomRuntimeException.class)
+    public ResponseEntity<ExceptionDto> customException(CustomRuntimeException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        log.error("CustomException 발생 : {} \n HttpStatus : {} \n Message : {} \n StackTrace : {}",
+            errorCode.name(), errorCode.getHttpStatus().toString(),
+            errorCode.getMessage(), ex.getStackTrace());
+
+        return new ResponseEntity<>(
+            ExceptionDto.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build()
+            , errorCode.getHttpStatus()
+        );
+    }
+
+    /**
+     * 핸들링되지 못한 exception에 대한 처리 (500, internal server error)
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionDto> unknownException(Exception ex) {
+        ErrorCode errorCode = ErrorCode.UNKNOWN_EXCEPTION;
+        log.error("UnknownException 발생 : {} \n HttpStatus : {} \n Message : {} \n StackTrace : {}",
+            errorCode.name(), errorCode.getHttpStatus().toString(),
+            errorCode.getMessage(), ex.getStackTrace());
+
+        return new ResponseEntity<>(
+            ExceptionDto.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build()
+            , errorCode.getHttpStatus()
+        );
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.avg.lawsuitmanagement.common.exception.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    
+    //500 발생
+    UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 예외가 발생했습니다."),
+    
+    EXCEPTION_AOP_TEST(HttpStatus.BAD_REQUEST, "TEST : 테스트용 예외가 발생했습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.");
+    private final HttpStatus httpStatus; // header에 담길 정보
+    private final String message;
+}


### PR DESCRIPTION
Background
---
예외처리에 aop를 적용한다. 달성하고자 하는 목표는 다음과 같다.
첫째, **api에서 발생하는 모든 예외에 대해서, 일관성 있는 예외 response를 반환한다.(ExceptionDto를 반환)**
둘째, 모든 비지니스 에러를, Enum인 ErrorCode.java에서 한눈에 확인할 수 있도록 한다.

자체 에러코드는 정의하지 않는다. 대신 HttpStatus를 사용한다. 왜냐하면 HttpStatus가 더 일반적이고 관리가 편하기 때문이다.
참고 : https://developer.mozilla.org/en-US/docs/Web/HTTP/Status

Change
---
GlobalExceptionHandler에서 모든 예외를 핸들링한다. 개발자가 잡아내지 못한 에러는 unknownException(Exception) 메소드에서 잡아내며, response에는 "알 수 없는 예외" 로 표기된다.

Discuss
---
서비스 구현 시 비즈니스 에러를 발생 시키려면 다음과 같은 절차를 따르면 된다.
1. Enum ErrorCode에 발생시키고자 하는 예외를 정의한다. 이 때, 내용이 중복되는 에러가 있지는 않은 지 충분히 확인해야 한다. ErrorCode에는 예외명, HttpStatus 종류, 상세메시지 가 들어간다. ex ) TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.");
2. 서비스에서 CustomRuntimeException에 에러코드를 담아 throw 한다.
ex) throw new CustomRuntimeException(ErrorCode.TOKEN_NOT_FOUND)
3. 이후 throw된 예외는 handler에서 받아서 자동으로 처리된다.