### PR TITLE
토큰 인증 예외처리 추가

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/JwtFilter.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/JwtFilter.java
@@ -30,13 +30,14 @@ public class JwtFilter extends OncePerRequestFilter {
         String jwt = resolveToken(request);
 
         //2. 토큰 유효성 검사
-
-        if (jwt == null || !tokenProvider.validateToken(jwt)) {
-
-            log.error("AUTHORIZATION을 잘못 보냈습니다.");
-            filterChain.doFilter(request, response);
+        try {
+            tokenProvider.validateToken(jwt);
+        } catch (Exception e) {
+            request.setAttribute("ex", e);
+            filterChain.doFilter(request,response);
             return;
         }
+
 // 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
         Authentication authentication = tokenProvider.getAuthentication(jwt);
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.common.config;
 
 
+import com.avg.lawsuitmanagement.common.exception.CustomAuthenticationEntryPoint;
 import com.avg.lawsuitmanagement.token.provider.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,7 +23,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
-//    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -38,7 +39,7 @@ public class SecurityConfig {
 
             .and()
             .authorizeRequests()
-            .antMatchers("/token/**").permitAll() //열어줄 요청들 표기
+            .antMatchers("/token/**", "/test2").permitAll() //열어줄 요청들 표기
 
             //for test
             //테스트 메소드는 admin 권한이 있어야 가능
@@ -52,13 +53,15 @@ public class SecurityConfig {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
             //인증 간 예외처리
-//            .and()
-//            .exceptionHandling()
-//            .authenticationEntryPoint(customAuthenticationEntryPoint)
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
 
             .and()
             .addFilterBefore(new JwtFilter(tokenProvider),
                 UsernamePasswordAuthenticationFilter.class)
+
+
             .build();
     }
 

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.avg.lawsuitmanagement.common.exception;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+/*
+시큐리티에서 예외처리를 위해 사용하는 클래스
+ */
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Autowired
+    @Qualifier("handlerExceptionResolver")
+    private HandlerExceptionResolver resolver;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) {
+
+        resolver.resolveException(request, response, null, (Exception) request.getAttribute("ex"));
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/dto/ExceptionDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/dto/ExceptionDto.java
@@ -2,11 +2,13 @@ package com.avg.lawsuitmanagement.common.exception.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Builder
 @RequiredArgsConstructor
 @AllArgsConstructor
+@Getter
 public class ExceptionDto {
     private String code;
     private String message;

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/dto/ExceptionDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/dto/ExceptionDto.java
@@ -1,10 +1,12 @@
 package com.avg.lawsuitmanagement.common.exception.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
 @Builder
 @RequiredArgsConstructor
+@AllArgsConstructor
 public class ExceptionDto {
     private String code;
     private String message;

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -10,9 +10,14 @@ public enum ErrorCode {
     
     //500 발생
     UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 예외가 발생했습니다."),
+
+    //JWT 관련 예외
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    TOKEN_WRONG(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다"),
     
-    EXCEPTION_AOP_TEST(HttpStatus.BAD_REQUEST, "TEST : 테스트용 예외가 발생했습니다."),
-    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.");
+    EXCEPTION_AOP_TEST(HttpStatus.BAD_REQUEST, "TEST : 테스트용 예외가 발생했습니다.");
+
     private final HttpStatus httpStatus; // header에 담길 정보
     private final String message;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/token/controller/TestController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/controller/TestController.java
@@ -13,7 +13,14 @@ public class TestController {
     @GetMapping("/test")
     public void testMethod() {
 
-        System.out.println("테스트 성공");
+        System.out.println("컨트롤러 도달");
     }
+
+    @GetMapping("/test2")
+    public void testMethod2() {
+//        throw new CustomRuntimeException(ErrorCode.TOKEN_NOT_FOUND);
+        System.out.println("컨트롤러 도달");
+    }
+
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/token/provider/TokenProvider.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/provider/TokenProvider.java
@@ -1,10 +1,14 @@
 package com.avg.lawsuitmanagement.token.provider;
 
 
+import com.avg.lawsuitmanagement.common.exception.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import com.avg.lawsuitmanagement.token.dto.JwtTokenDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.token.service.CustomUserDetail;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -59,14 +63,19 @@ public class TokenProvider {
     /*
     토큰이 적법한지 검증한다.
      */
-    public boolean validateToken(String token) {
+    public void validateToken(String token) {
+
+        if(token == null) {
+            throw new CustomRuntimeException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (Exception e) {
-            log.info(e.getMessage());
+        } catch (ExpiredJwtException e) {
+            throw new CustomRuntimeException(ErrorCode.TOKEN_EXPIRED);
+        } catch (JwtException e) {
+            throw new CustomRuntimeException(ErrorCode.TOKEN_WRONG);
         }
-        return false;
     }
 
     public Authentication getAuthentication(String accessToken) {


### PR DESCRIPTION
문제점
---
목표는 JWT 토큰에 대한 다양한 예외를 다른 예외와 마찬가지로 일관성 있는 형식으로 반환하는 것이다. 이를 위해서 기존 AOP 방식으로 구현해 둔 GlobalExceptionHandler(RestControllerAdvice) 를 통해서 예외를 처리하고자 했다.
그런데, 시큐리티에서 인증/인가는 필터에서 이루어진다. 필터를 거치는 시점은 DispatcherServlet에 도달하기 전이기 때문에, JwtFilter에서 예외를 throw 한다고 해서 handler에서 받아낼 수 없다.

해결법
---
시큐리티에서 인증과 관련된 문제가 발생할 경우, 거치는 EntryPoint로 AuthenticationEntryPoint 라는 것이 있다. AuthenticationEntryPoint의 custom 구현체를 직접 만들어 문제를 해결했다. customEntryPoint에서는 HandlerExceptionResolver를 의존한다. HandlerExceptionResolver는 스프링MVC에서 제공하는 것으로, 컨트롤러 밖에서 일어나는 예외를 핸들링하는 빈이다.

흐름
---
TokenProvider에서 토큰 관련 예외 발생 -> JwtFilter에서 request에 담아서 EntryPoint로 넘긴다 -> EntryPoint에서 HandlerExceptionResolver을 통해 해당 에러를 핸들링 -> 최초 목표인 GlobalExceptionHandler로 넘어간다.