### PR TITLE
로그인 예외처리

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.avg.lawsuitmanagement.common.config;
 
 
-import com.avg.lawsuitmanagement.common.exception.CustomAuthenticationEntryPoint;
+import com.avg.lawsuitmanagement.common.custom.CustomAuthenticationEntryPoint;
 import com.avg.lawsuitmanagement.token.provider.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
 
             .and()
             .authorizeRequests()
-            .antMatchers("/token/**", "/test2").permitAll() //열어줄 요청들 표기
+            .antMatchers("/tokens/**", "/test2").permitAll() //열어줄 요청들 표기
 
             //for test
             //테스트 메소드는 admin 권한이 있어야 가능

--- a/src/main/java/com/avg/lawsuitmanagement/common/custom/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/custom/CustomAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.avg.lawsuitmanagement.common.exception;
+package com.avg.lawsuitmanagement.common.custom;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/com/avg/lawsuitmanagement/common/custom/CustomRuntimeException.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/custom/CustomRuntimeException.java
@@ -1,4 +1,4 @@
-package com.avg.lawsuitmanagement.common.exception;
+package com.avg.lawsuitmanagement.common.custom;
 
 import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/handler/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package com.avg.lawsuitmanagement.common.exception.handler;
 
-import com.avg.lawsuitmanagement.common.exception.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.exception.dto.ExceptionDto;
 import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -18,9 +20,25 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomRuntimeException.class)
     public ResponseEntity<ExceptionDto> customException(CustomRuntimeException ex) {
         ErrorCode errorCode = ex.getErrorCode();
-        log.error("CustomException 발생 : {} \n HttpStatus : {} \n Message : {} \n StackTrace : {}",
+        log.error("CustomException 발생 : {} \n HttpStatus : {} \n Message : {} \n ExceptionDetail : {}",
             errorCode.name(), errorCode.getHttpStatus().toString(),
-            errorCode.getMessage(), ex.getStackTrace());
+            errorCode.getMessage(), ex.toString());
+
+        return new ResponseEntity<>(
+            ExceptionDto.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build()
+            , errorCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ExceptionDto> badCredentialsException(BadCredentialsException ex) {
+        ErrorCode errorCode = ErrorCode.BAD_CREDENTIAL;
+        log.error("UnknownException 발생 : {} \n HttpStatus : {} \n Message : {} \n ExceptionDetail : {}",
+            errorCode.name(), errorCode.getHttpStatus().toString(),
+            errorCode.getMessage(), ex.toString());
 
         return new ResponseEntity<>(
             ExceptionDto.builder()
@@ -37,9 +55,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionDto> unknownException(Exception ex) {
         ErrorCode errorCode = ErrorCode.UNKNOWN_EXCEPTION;
-        log.error("UnknownException 발생 : {} \n HttpStatus : {} \n Message : {} \n StackTrace : {}",
+        log.error("UnknownException 발생 : {} \n HttpStatus : {} \n Message : {} \n ExceptionDetail : {}",
             errorCode.name(), errorCode.getHttpStatus().toString(),
-            errorCode.getMessage(), ex.getStackTrace());
+            errorCode.getMessage(), ex.toString());
 
         return new ResponseEntity<>(
             ExceptionDto.builder()

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     //500 발생
     UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 예외가 발생했습니다."),
 
+    //계정관련
+    BAD_CREDENTIAL(HttpStatus.NOT_FOUND, "존재하지 않는 계정이거나 비밀번호가 틀렸습니다."),
+
     //JWT 관련 예외
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/main/java/com/avg/lawsuitmanagement/token/provider/TokenProvider.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/provider/TokenProvider.java
@@ -1,7 +1,7 @@
 package com.avg.lawsuitmanagement.token.provider;
 
 
-import com.avg.lawsuitmanagement.common.exception.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import com.avg.lawsuitmanagement.token.dto.JwtTokenDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;

--- a/src/main/java/com/avg/lawsuitmanagement/token/service/CustomUserDetailsService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.avg.lawsuitmanagement.token.service;
 
+import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +19,12 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String username) {
 
-        return new CustomUserDetail(memberMapperRepository.selectMemberByEmail(username));
+        MemberDto member = memberMapperRepository.selectMemberByEmail(username);
+        if(member == null) {
+            throw new UsernameNotFoundException("");
+        }
+        return new CustomUserDetail(member);
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/token/service/TokenService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/service/TokenService.java
@@ -49,12 +49,7 @@ public class TokenService {
         //실질적인 검증단계
         //authenticate 메소드가 실행 될 때 CustomUserDetailService.loadUserByUsername이 실행된다.
         //즉, 사용자가 입력한 정보와 db 정보가 일치하는지 검증한다.
-        try {
-            return authenticationManagerBuilder.getObject()
-                .authenticate(authenticationToken);
-        } catch (Exception ex) {
-            log.error(ex.getMessage());
-            throw new RuntimeException("로그인 실패");
-        }
+        return authenticationManagerBuilder.getObject()
+            .authenticate(authenticationToken);
     }
 }


### PR DESCRIPTION
Background
---
로그인 시 아이디/비밀번호가 틀렸을 경우 적절한 메시지를 프론트에게 반환해야 한다.

Change & Analatics
---
로그인 시 예외가 발생하는 경우는 두 가지이다. 1. 비밀번호가 틀린 경우, 2. 계정이 존재하지 않는 경우
시큐리티에서는 기본적으로 "오류 은폐 원칙"에 따라, 두 예외를 같은 것으로 취급해야 한다.
이 원칙을 지켜서, 두 경우 모두 같은 예외가 발생하도록 구현하였다. DB에 계정이 없을 경우, UsernameNotFoundExcetpion을 throw 하고, 시큐리티에서 이를 잡아채서 BadCredectialsException으로 감싼다. 비밀번호가 틀렸을 경우에는 BadCredectialsException을 바로 발생시킨다. BadCredectialsException는 다른 예외들과 마찬가지로 GlobalExceptionHandler에서 처리된다.

Test
---
postman을 통한 테스트 완료

