### PR TITLE
의뢰인 조회, 수정, 삭제 서비스 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
@@ -4,6 +4,7 @@ import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
 import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.service.ClientService;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -43,9 +44,9 @@ public class ClientController {
     }
 
     @GetMapping()
-    public ResponseEntity<Void> getClientList() {
+    public ResponseEntity<List<ClientDto>> getClientList() {
         clientService.getClientList();
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(clientService.getClientList());
     }
 }
 

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
@@ -6,6 +6,7 @@ import com.avg.lawsuitmanagement.client.service.ClientService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,6 +31,12 @@ public class ClientController {
     @PutMapping("/{clientId}")
     public ResponseEntity<Void> updateClientInfo(@PathVariable("clientId") Long clientId, @RequestBody @Valid UpdateClientInfoForm form) {
         clientService.updateClientInfo(clientId, form);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{clientId}")
+    public ResponseEntity<Void> deleteClientInfo(@PathVariable("clientId") Long clientId) {
+        clientService.deleteClientInfo(clientId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
@@ -1,11 +1,14 @@
 package com.avg.lawsuitmanagement.client.controller;
 
 import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
+import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.service.ClientService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +22,14 @@ public class ClientController {
 
     // 의뢰인 등록
     @PostMapping()
-    public ResponseEntity insertClient(@RequestBody @Valid InsertClientForm form) {
+    public ResponseEntity<Void> insertClient(@RequestBody @Valid InsertClientForm form) {
         clientService.insertClient(form);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{clientId}")
+    public ResponseEntity<Void> updateClientInfo(@PathVariable("clientId") Long clientId, @RequestBody @Valid UpdateClientInfoForm form) {
+        clientService.updateClientInfo(clientId, form);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
@@ -2,10 +2,12 @@ package com.avg.lawsuitmanagement.client.controller;
 
 import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
 import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
+import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.service.ClientService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,6 +39,12 @@ public class ClientController {
     @PatchMapping("/{clientId}")
     public ResponseEntity<Void> deleteClientInfo(@PathVariable("clientId") Long clientId) {
         clientService.deleteClientInfo(clientId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping()
+    public ResponseEntity<Void> getClientList() {
+        clientService.getClientList();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/form/InsertClientForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/form/InsertClientForm.java
@@ -1,7 +1,6 @@
 package com.avg.lawsuitmanagement.client.controller.form;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import lombok.Getter;

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/form/UpdateClientInfoForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/form/UpdateClientInfoForm.java
@@ -1,0 +1,21 @@
+package com.avg.lawsuitmanagement.client.controller.form;
+
+import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateClientInfoForm {
+    @Email
+    private String email;
+    @Size(min=2, max=10)
+    private String name;
+    @Size(min=13, max=13)
+    private String phone;
+    @NotBlank
+    private String address;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/form/UpdateClientInfoForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/form/UpdateClientInfoForm.java
@@ -1,6 +1,5 @@
 package com.avg.lawsuitmanagement.client.controller.form;
 
-import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -5,6 +5,7 @@ import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
 import org.apache.ibatis.annotations.Mapper;
+import java.util.HashMap;
 
 @Mapper
 public interface ClientMapperRepository {
@@ -13,5 +14,5 @@ public interface ClientMapperRepository {
     ClientDto selectClientByEmail(String email);
     void insertClient(InsertClientParam param);
     void updateClientMemberId(UpdateClientMemberIdParam param);
-    void updateClientInfo(UpdateClientInfoParam param);
+    void updateClientInfo(HashMap map);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -4,8 +4,8 @@ import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
-import org.apache.ibatis.annotations.Mapper;
 import java.util.HashMap;
+import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface ClientMapperRepository {
@@ -14,5 +14,5 @@ public interface ClientMapperRepository {
     ClientDto selectClientByEmail(String email);
     void insertClient(InsertClientParam param);
     void updateClientMemberId(UpdateClientMemberIdParam param);
-    void updateClientInfo(HashMap map);
+    void updateClientInfo(UpdateClientInfoParam param);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -5,6 +5,7 @@ import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
 import java.util.HashMap;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
@@ -16,4 +17,5 @@ public interface ClientMapperRepository {
     void updateClientMemberId(UpdateClientMemberIdParam param);
     void updateClientInfo(UpdateClientInfoParam param);
     void deleteClientInfo(long clientId);
+    List<ClientDto> getClientList();
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.client.repository;
 
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
+import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -12,4 +13,5 @@ public interface ClientMapperRepository {
     ClientDto selectClientByEmail(String email);
     void insertClient(InsertClientParam param);
     void updateClientMemberId(UpdateClientMemberIdParam param);
+    void updateClientInfo(UpdateClientInfoParam param);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -15,4 +15,5 @@ public interface ClientMapperRepository {
     void insertClient(InsertClientParam param);
     void updateClientMemberId(UpdateClientMemberIdParam param);
     void updateClientInfo(UpdateClientInfoParam param);
+    void deleteClientInfo(long clientId);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/param/UpdateClientInfoParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/param/UpdateClientInfoParam.java
@@ -1,5 +1,6 @@
 package com.avg.lawsuitmanagement.client.repository.param;
 
+import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,4 +13,13 @@ public class UpdateClientInfoParam {
     private String name;
     private String phone;
     private String address;
+
+    public static UpdateClientInfoParam of(UpdateClientInfoForm form) {
+        return UpdateClientInfoParam.builder()
+            .email(form.getEmail())
+            .name(form.getName())
+            .phone(form.getPhone())
+            .address(form.getAddress())
+            .build();
+    }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/param/UpdateClientInfoParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/param/UpdateClientInfoParam.java
@@ -1,0 +1,15 @@
+package com.avg.lawsuitmanagement.client.repository.param;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UpdateClientInfoParam {
+    private String email;
+    private String name;
+    private String phone;
+    private String address;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/param/UpdateClientInfoParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/param/UpdateClientInfoParam.java
@@ -9,13 +9,15 @@ import lombok.Setter;
 @Setter
 @Builder
 public class UpdateClientInfoParam {
+    private Long clientId;
     private String email;
     private String name;
     private String phone;
     private String address;
 
-    public static UpdateClientInfoParam of(UpdateClientInfoForm form) {
+    public static UpdateClientInfoParam of(Long clientId, UpdateClientInfoForm form) {
         return UpdateClientInfoParam.builder()
+            .clientId(clientId)
             .email(form.getEmail())
             .name(form.getName())
             .phone(form.getPhone())

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -10,6 +10,7 @@ import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -66,7 +67,7 @@ public class ClientService {
         clientMapperRepository.deleteClientInfo(clientId);
     }
 
-    public void getClientList() {
-        clientMapperRepository.getClientList();
+    public List<ClientDto> getClientList() {
+        return clientMapperRepository.getClientList();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -52,10 +52,6 @@ public class ClientService {
             throw new CustomRuntimeException(CLIENT_NOT_FOUND);
         }
 
-        HashMap<String, Object> map = new HashMap<>();
-        map.put("clientId", clientId);
-        map.put("form", UpdateClientInfoParam.of(form));
-
-        clientMapperRepository.updateClientInfo(map);
+        clientMapperRepository.updateClientInfo(UpdateClientInfoParam.of(clientId, form));
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -54,4 +54,15 @@ public class ClientService {
 
         clientMapperRepository.updateClientInfo(UpdateClientInfoParam.of(clientId, form));
     }
+
+    public void deleteClientInfo(long clientId) {
+        ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
+
+        // 해당 clientId의 의뢰인이 없을 경우
+        if (clientDto == null) {
+            throw new CustomRuntimeException(CLIENT_NOT_FOUND);
+        }
+
+        clientMapperRepository.deleteClientInfo(clientId);
+    }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -4,13 +4,16 @@ import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_A
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_NOT_FOUND;
 
 import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
+import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
+import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import java.util.HashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +42,20 @@ public class ClientService {
 
         // 등록된 고객이 아니면 db 입력
         clientMapperRepository.insertClient(InsertClientParam.of(form));
+    }
+
+    public void updateClientInfo(long clientId, UpdateClientInfoForm form) {
+        ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
+
+        // 해당 clientId의 의뢰인이 없을 경우
+        if (clientDto == null) {
+            throw new CustomRuntimeException(CLIENT_NOT_FOUND);
+        }
+
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("clientId", clientId);
+        map.put("form", UpdateClientInfoParam.of(form));
+
+        clientMapperRepository.updateClientInfo(map);
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -65,4 +65,8 @@ public class ClientService {
 
         clientMapperRepository.deleteClientInfo(clientId);
     }
+
+    public void getClientList() {
+        clientMapperRepository.getClientList();
+    }
 }

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -39,4 +39,10 @@
         set is_deleted = true
         where id = #{clientId};
     </update>
+
+    <select id="getClientList">
+        select *
+        from client
+        where is_deleted = false;
+    </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -28,5 +28,11 @@
         where id = #{clientId};
     </update>
 
+    <update id="updateClientInfo" parameterType="UpdateClientInfoParam">
+        update client
+        set {email, name, phone, address}
+        where id = #{clientId}
+    </update>
+
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -8,13 +8,13 @@
     <select id="selectClientById" parameterType="java.lang.Long">
         select *
         from client
-        where id = #{clientId};
+        where id = #{clientId} and is_deleted=false;;
     </select>
 
     <select id="selectClientByEmail" parameterType="java.lang.String">
         select *
         from client
-        where email = #{email};
+        where email = #{email} and is_deleted=false;;
     </select>
 
     <insert id="insertClient" parameterType="InsertClientParam">
@@ -31,7 +31,7 @@
     <update id="updateClientInfo" parameterType="UpdateClientInfoParam">
         update client
         set email=#{email}, name=#{name}, phone=#{phone}, address=#{address}
-        where id = #{clientId}
+        where id = #{clientId};
     </update>
 
 

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -8,13 +8,13 @@
     <select id="selectClientById" parameterType="java.lang.Long">
         select *
         from client
-        where id = #{clientId} and is_deleted=false;;
+        where id = #{clientId} and is_deleted = false;
     </select>
 
     <select id="selectClientByEmail" parameterType="java.lang.String">
         select *
         from client
-        where email = #{email} and is_deleted=false;;
+        where email = #{email} and is_deleted = false;
     </select>
 
     <insert id="insertClient" parameterType="InsertClientParam">
@@ -30,9 +30,13 @@
 
     <update id="updateClientInfo" parameterType="UpdateClientInfoParam">
         update client
-        set email=#{email}, name=#{name}, phone=#{phone}, address=#{address}
+        set email = #{email}, name = #{name}, phone = #{phone}, address = #{address}
         where id = #{clientId};
     </update>
 
-
+    <update id="deleteClientInfo" parameterType="java.lang.Long">
+        update client
+        set is_deleted = true
+        where id = #{clientId};
+    </update>
 </mapper>

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -5,7 +5,7 @@
 
 <mapper namespace="com.avg.lawsuitmanagement.client.repository.ClientMapperRepository">
 
-    <select id="selectClientById">
+    <select id="selectClientById" parameterType="java.lang.Long">
         select *
         from client
         where id = #{clientId};
@@ -28,9 +28,9 @@
         where id = #{clientId};
     </update>
 
-    <update id="updateClientInfo" parameterType="UpdateClientInfoParam">
+    <update id="updateClientInfo" parameterType="java.util.HashMap">
         update client
-        set {email, name, phone, address}
+        set email=#{form.email}, name=#{form.name}, phone=#{form.phone}, address=#{form.address}
         where id = #{clientId}
     </update>
 

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -28,9 +28,9 @@
         where id = #{clientId};
     </update>
 
-    <update id="updateClientInfo" parameterType="java.util.HashMap">
+    <update id="updateClientInfo" parameterType="UpdateClientInfoParam">
         update client
-        set email=#{form.email}, name=#{form.name}, phone=#{form.phone}, address=#{form.address}
+        set email=#{email}, name=#{name}, phone=#{phone}, address=#{address}
         where id = #{clientId}
     </update>
 


### PR DESCRIPTION
Background
---
직원이 의뢰인을 조회하거나 수정 및 삭제 할 수 있다.

Change
---
조회 - is_deleted 속성이 false인 의뢰인(삭제되지 않은 의뢰인)들을 모두 조회하는 기능을 구현
수정 - 의뢰인 정보가 변경될 경우, 해당 의뢰인의 정보를 수정하고 해당 데이터를 DB에 UPDATE하는 기능을 구현
삭제 - 의뢰인의 정보를 삭제할 때, 실제 DB에는 삭제하는 것이 아닌 is_deleted 속성을 true로 UPDATE한다.

Exception
---
의뢰인 정보를 수정하거나 삭제할 때 해당 의뢰인의 id로 의뢰인 DB에 존재하는지 검사한다.
만약 해당 id의 의뢰인이 없으면 ClientNotFoundException을 발생시킨다.

Test
---
postman을 통한 테스트 완료

Discuss
---
InsertClientForm과 UpdateClientForm의 코드가 100% 동일한데, 이런 중복되는 코드들을 따로 나눠서 관리해야하는지 의문입니다.