### PR TITLE
직원 회원가입 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.member.controller;
 
 import com.avg.lawsuitmanagement.member.controller.form.ClientSignUpForm;
+import com.avg.lawsuitmanagement.member.controller.form.EmployeeSignUpForm;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.service.MemberService;
 import javax.validation.Valid;
@@ -27,6 +28,12 @@ public class MemberController {
     @PostMapping("/clients")
     public ResponseEntity<Void> clientSignUp(@RequestBody @Valid ClientSignUpForm form) {
         memberService.clientSignUp(form);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/employees")
+    public ResponseEntity<Void> employeeSignUp(@RequestBody @Valid EmployeeSignUpForm form) {
+        memberService.employeeSignUp(form);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/avg/lawsuitmanagement/member/controller/form/EmployeeSignUpForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/controller/form/EmployeeSignUpForm.java
@@ -1,0 +1,30 @@
+package com.avg.lawsuitmanagement.member.controller.form;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class EmployeeSignUpForm {
+    @NotBlank
+    private String promotionKey;
+    @Email
+    private String email;
+    @NotBlank
+    private String password;
+    @Size(min=2, max=10)
+    private String name;
+    @Size(min=13, max=13)
+    private String phone;
+    @NotBlank
+    private String address;
+    @NotBlank
+    private long hierarchyId;
+    @NotBlank
+    private long roleId;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/repository/param/InsertMemberParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/repository/param/InsertMemberParam.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.member.repository.param;
 
 import com.avg.lawsuitmanagement.member.controller.form.ClientSignUpForm;
+import com.avg.lawsuitmanagement.member.controller.form.EmployeeSignUpForm;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -29,6 +30,18 @@ public class InsertMemberParam {
             .hierarchyId(1) //고민 필요
             .address(form.getAddress())
             .roleId(1) //고민필요
+            .build();
+    }
+
+    public static InsertMemberParam of(EmployeeSignUpForm form, PasswordEncoder passwordEncoder) {
+        return InsertMemberParam.builder()
+            .email(form.getEmail())
+            .password(passwordEncoder.encode(form.getPassword()))
+            .name(form.getName())
+            .phone(form.getPhone())
+            .hierarchyId(form.getHierarchyId())
+            .address(form.getAddress())
+            .roleId(form.getRoleId())
             .build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdPar
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.util.SecurityUtil;
 import com.avg.lawsuitmanagement.member.controller.form.ClientSignUpForm;
+import com.avg.lawsuitmanagement.member.controller.form.EmployeeSignUpForm;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
 import com.avg.lawsuitmanagement.member.repository.param.InsertMemberParam;
@@ -52,6 +53,16 @@ public class MemberService {
                 .clientId(clientDto.getId())
                 .memberId(memberId)
             .build());
+    }
+
+    @Transactional
+    public void employeeSignUp(EmployeeSignUpForm form) {
+        //1. 가입키 검증
+        promotionService.validateEmployeePromotionKey(form.getPromotionKey());
+        //2. 키 비활성화
+        promotionService.deactivateEmployeePromotion(form.getPromotionKey());
+        //3. 데이터 삽입
+        insertMember(InsertMemberParam.of(form, passwordEncoder));
     }
 
     private long insertMember(InsertMemberParam param) {

--- a/src/test/java/com/avg/lawsuitmanagement/member/MemberServiceTest.java
+++ b/src/test/java/com/avg/lawsuitmanagement/member/MemberServiceTest.java
@@ -13,11 +13,13 @@ import com.avg.lawsuitmanagement.client.service.ClientService;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import com.avg.lawsuitmanagement.member.controller.form.ClientSignUpForm;
+import com.avg.lawsuitmanagement.member.controller.form.EmployeeSignUpForm;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
 import com.avg.lawsuitmanagement.member.repository.param.InsertMemberParam;
 import com.avg.lawsuitmanagement.member.service.MemberService;
 import com.avg.lawsuitmanagement.promotion.dto.ClientPromotionKeyDto;
+import com.avg.lawsuitmanagement.promotion.dto.EmployeePromotionKeyDto;
 import com.avg.lawsuitmanagement.promotion.repository.PromotionMapperRepository;
 import com.avg.lawsuitmanagement.promotion.service.PromotionService;
 import org.junit.jupiter.api.DisplayName;
@@ -190,6 +192,50 @@ public class MemberServiceTest {
         clientMapperRepository.insertClient(param);
         ClientDto clientDto = clientMapperRepository.selectClientByEmail(param.getEmail());
         return clientDto.getId();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("직원 회원가입 성공")
+    void EmployeeSignUpSuccess() {
+        //given
+        String email = "cofee123@naver.com";
+        String password = "1234";
+        String name = "김커피";
+        String phone = "010-1564-4848";
+        String address = "커피하우스";
+        long hierarchyId = 2L;
+        long roleId = 2L;
+
+        String promotionKey = promotionService.createEmployeePromotionKey();
+
+        //when
+        memberService.employeeSignUp(EmployeeSignUpForm.builder()
+            .promotionKey(promotionKey)
+            .email(email)
+            .password(password)
+            .name(name)
+            .phone(phone)
+            .address(address)
+            .hierarchyId(hierarchyId)
+            .roleId(roleId)
+            .build()
+        );
+
+        //then
+        MemberDto memberDto = memberMapperRepository.selectMemberByEmail(email);
+        EmployeePromotionKeyDto employeePromotionKeyDto = promotionMapperRepository.selectEmployeePromotionKeyByValue(
+            promotionKey);
+
+        //member 테이블 검증
+        assertNotNull(memberDto);
+        assertEquals(name, memberDto.getName());
+        assertEquals(email, memberDto.getEmail());
+        assertEquals(phone, memberDto.getPhone());
+        assertEquals(address, memberDto.getAddress());
+
+        //employee_promotion 검증
+        assertFalse(employeePromotionKeyDto.isActive());
     }
 
 }


### PR DESCRIPTION
Background
---
직원은 발급 된 가입키를 통해 회원가입 할 수 있다.

Change
---
직원 회원가입 요청 시 다음과 같은 일이 일어난다.
가입키 검증 -> 가입키가 활성화 상태인지 확인 (promotionService에 위임)
이메일이 중복되지는 않았는지 확인 (MEMBER_EMAIL_ALREADY_EXIST 발생)
해당 프로모션 키를 비활성화한다
회원 테이블에 회원을 추가한다.

Test
---
단위 테스트 작성 완료