### PR TITLE
직책, 역할, 법원 api 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 
             .and()
             .authorizeRequests()
-            .antMatchers("/tokens/**", "/test/**").permitAll()
+            .antMatchers("/tokens/**", "/test/**", "/hierarchy/**").permitAll()
             .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()
             .antMatchers(HttpMethod.POST, "/members/clients").permitAll()
             .antMatchers(HttpMethod.POST, "/promotions/clients").hasAnyRole("ADMIN", "EMPLOYEE")

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 
             .and()
             .authorizeRequests()
-            .antMatchers("/tokens/**", "/test/**", "/hierarchy/**").permitAll()
+            .antMatchers("/tokens/**", "/test/**", "/hierarchy/**", "/role/**", "/court/**" ).permitAll()
             .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()
             .antMatchers(HttpMethod.POST, "/members/clients").permitAll()
             .antMatchers(HttpMethod.POST, "/promotions/clients").hasAnyRole("ADMIN", "EMPLOYEE")

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -32,7 +32,13 @@ public enum ErrorCode {
     //의뢰인 관련 예외
     CLIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 의뢰인입니다."),
     CLIENT_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 등록된 의뢰인입니다."),
-
+    
+    //직책, 역할, 법원
+    HIERARCHY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 직책입니다."),
+    ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 역할입니다."),
+    COURT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 법원입니다."),
+    
+    
     //TEST
     EXCEPTION_AOP_TEST(HttpStatus.BAD_REQUEST, "TEST : 테스트용 예외가 발생했습니다.");
 

--- a/src/main/java/com/avg/lawsuitmanagement/data/controller/CourtController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/controller/CourtController.java
@@ -1,0 +1,29 @@
+package com.avg.lawsuitmanagement.data.controller;
+
+import com.avg.lawsuitmanagement.data.dto.CourtDto;
+import com.avg.lawsuitmanagement.data.service.CourtService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/court")
+public class CourtController {
+
+    private final CourtService courtService;
+
+    @GetMapping
+    public ResponseEntity<List<CourtDto>> getCourtList() {
+        return ResponseEntity.ok(courtService.getCourtList());
+    }
+
+    @GetMapping("/{courtId}")
+    public ResponseEntity<CourtDto> getCourt(@PathVariable long courtId) {
+        return ResponseEntity.ok(courtService.getCourt(courtId));
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/controller/HierarchyController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/controller/HierarchyController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,8 +17,13 @@ public class HierarchyController {
 
     private final HierarchyService hierarchyService;
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<List<HierarchyDto>> getHierarchyList() {
         return ResponseEntity.ok(hierarchyService.getHierarchyList());
+    }
+
+    @GetMapping("/{hierarchyId}")
+    public ResponseEntity<HierarchyDto> getHierarchy(@PathVariable long hierarchyId) {
+        return ResponseEntity.ok(hierarchyService.getHierarchy(hierarchyId));
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/data/controller/HierarchyController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/controller/HierarchyController.java
@@ -1,0 +1,23 @@
+package com.avg.lawsuitmanagement.data.controller;
+
+import com.avg.lawsuitmanagement.data.dto.HierarchyDto;
+import com.avg.lawsuitmanagement.data.service.HierarchyService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hierarchy")
+public class HierarchyController {
+
+    private final HierarchyService hierarchyService;
+
+    @GetMapping()
+    public ResponseEntity<List<HierarchyDto>> getHierarchyList() {
+        return ResponseEntity.ok(hierarchyService.getHierarchyList());
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/controller/RoleController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/controller/RoleController.java
@@ -1,0 +1,29 @@
+package com.avg.lawsuitmanagement.data.controller;
+
+import com.avg.lawsuitmanagement.data.dto.RoleDto;
+import com.avg.lawsuitmanagement.data.service.RoleService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/role")
+public class RoleController {
+
+    private final RoleService roleService;
+
+    @GetMapping
+    public ResponseEntity<List<RoleDto>> getRoleList() {
+        return ResponseEntity.ok(roleService.getRoleList());
+    }
+
+    @GetMapping("/{roleId}")
+    public ResponseEntity<RoleDto> getRole(@PathVariable long roleId) {
+        return ResponseEntity.ok(roleService.getRole(roleId));
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/dto/CourtDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/dto/CourtDto.java
@@ -1,0 +1,13 @@
+package com.avg.lawsuitmanagement.data.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CourtDto {
+
+    long id;
+    String nameKr;
+    String nameEng;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/dto/HierarchyDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/dto/HierarchyDto.java
@@ -1,0 +1,13 @@
+package com.avg.lawsuitmanagement.data.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HierarchyDto {
+
+    long id;
+    String nameKr;
+    String nameEng;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/dto/RoleDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/dto/RoleDto.java
@@ -1,0 +1,13 @@
+package com.avg.lawsuitmanagement.data.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RoleDto {
+
+    long id;
+    String nameKr;
+    String nameEng;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/repository/CourtMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/repository/CourtMapperRepository.java
@@ -1,0 +1,12 @@
+package com.avg.lawsuitmanagement.data.repository;
+
+import com.avg.lawsuitmanagement.data.dto.CourtDto;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CourtMapperRepository {
+
+    List<CourtDto> selectCourtList();
+    CourtDto selectCourt(long id);
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/repository/HierarchyMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/repository/HierarchyMapperRepository.java
@@ -1,0 +1,12 @@
+package com.avg.lawsuitmanagement.data.repository;
+
+import com.avg.lawsuitmanagement.data.dto.HierarchyDto;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface HierarchyMapperRepository {
+
+    List<HierarchyDto> selectHierarchyList();
+    HierarchyDto selectHierarchyById(long id);
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/repository/RoleMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/repository/RoleMapperRepository.java
@@ -1,0 +1,12 @@
+package com.avg.lawsuitmanagement.data.repository;
+
+import com.avg.lawsuitmanagement.data.dto.RoleDto;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RoleMapperRepository {
+
+    List<RoleDto> selectRoleList();
+    RoleDto selectRoleById(long id);
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/service/CourtService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/service/CourtService.java
@@ -1,0 +1,29 @@
+package com.avg.lawsuitmanagement.data.service;
+
+import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
+import com.avg.lawsuitmanagement.data.dto.CourtDto;
+import com.avg.lawsuitmanagement.data.repository.CourtMapperRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CourtService {
+    private final CourtMapperRepository courtMapperRepository;
+
+    public List<CourtDto> getCourtList() {
+        return courtMapperRepository.selectCourtList();
+    }
+
+    public CourtDto getCourt(long id) {
+        CourtDto courtDto = courtMapperRepository.selectCourt(id);
+        if(courtDto == null) {
+            throw new CustomRuntimeException(ErrorCode.COURT_NOT_FOUND);
+        }
+        return courtDto;
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/service/HierarchyService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/service/HierarchyService.java
@@ -1,5 +1,7 @@
 package com.avg.lawsuitmanagement.data.service;
 
+import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import com.avg.lawsuitmanagement.data.dto.HierarchyDto;
 import com.avg.lawsuitmanagement.data.repository.HierarchyMapperRepository;
 import java.util.List;
@@ -15,5 +17,13 @@ public class HierarchyService {
 
     public List<HierarchyDto> getHierarchyList() {
         return hierarchyMapperRepository.selectHierarchyList();
+    }
+
+    public HierarchyDto getHierarchy(long id) {
+        HierarchyDto hierarchyDto = hierarchyMapperRepository.selectHierarchyById(id);
+        if(hierarchyDto == null) {
+            throw new CustomRuntimeException(ErrorCode.HIERARCHY_NOT_FOUND);
+        }
+        return hierarchyDto;
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/data/service/HierarchyService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/service/HierarchyService.java
@@ -1,0 +1,19 @@
+package com.avg.lawsuitmanagement.data.service;
+
+import com.avg.lawsuitmanagement.data.dto.HierarchyDto;
+import com.avg.lawsuitmanagement.data.repository.HierarchyMapperRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HierarchyService {
+    private final HierarchyMapperRepository hierarchyMapperRepository;
+
+    public List<HierarchyDto> getHierarchyList() {
+        return hierarchyMapperRepository.selectHierarchyList();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/data/service/RoleService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/data/service/RoleService.java
@@ -1,0 +1,29 @@
+package com.avg.lawsuitmanagement.data.service;
+
+import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
+import com.avg.lawsuitmanagement.data.dto.RoleDto;
+import com.avg.lawsuitmanagement.data.repository.RoleMapperRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoleService {
+    private final RoleMapperRepository roleMapperRepository;
+
+    public List<RoleDto> getRoleList() {
+        return roleMapperRepository.selectRoleList();
+    }
+
+    public RoleDto getRole(long id) {
+        RoleDto roleDto = roleMapperRepository.selectRoleById(id);
+        if(roleDto == null) {
+            throw new CustomRuntimeException(ErrorCode.ROLE_NOT_FOUND);
+        }
+        return roleDto;
+    }
+}

--- a/src/main/resources/mybatis/mapper/Court.xml
+++ b/src/main/resources/mybatis/mapper/Court.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.avg.lawsuitmanagement.data.repository.CourtMapperRepository">
+
+    <select id="selectCourtList" resultType="CourtDto">
+        select *
+        from court
+    </select>
+
+    <select id="selectCourt" resultType="CourtDto" parameterType="java.lang.Long">
+        select *
+        from court
+        where id = #{id}
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/Hierarchy.xml
+++ b/src/main/resources/mybatis/mapper/Hierarchy.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.avg.lawsuitmanagement.data.repository.HierarchyMapperRepository">
+
+    <select id="selectHierarchyList" resultType="HierarchyDto">
+        select *
+        from hierarchy
+    </select>
+
+    <select id="selectHierarchyById" resultType="HierarchyDto" parameterType="java.lang.Long">
+        select *
+        from hierarchy
+        where id = #{id}
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/Role.xml
+++ b/src/main/resources/mybatis/mapper/Role.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.avg.lawsuitmanagement.data.repository.RoleMapperRepository">
+
+    <select id="selectRoleList" resultType="RoleDto">
+        select *
+        from role
+    </select>
+
+    <select id="selectRoleById" resultType="RoleDto" parameterType="java.lang.Long">
+        select *
+        from role
+        where id = #{id}
+    </select>
+
+</mapper>


### PR DESCRIPTION
Background
---
확장 가능성이 있는 데이터는 테이블에서 별도의 테이블로 관리하기로 하였다.
이에 따라 직책, 역할, 법원 테이블은 별도의 테이블이 되며, 컨트롤러가 따로 있다.

Change
---
직책, 역할, 법원
각각 리스트조회, 단일조회 구현 / 없는 pk 조회요청시 not_found 예외 반환

Test
---
postman 테스트 완료