### PR TITLE
의뢰인-사건상세 탭 사건 리스트 및 페이징 정보

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
@@ -6,9 +6,6 @@ import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.dto.ClientLawsuitDto;
 import com.avg.lawsuitmanagement.client.service.ClientService;
-import com.avg.lawsuitmanagement.common.util.PagingUtil;
-import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
-import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,6 +27,12 @@ public class ClientController {
 
     private final ClientService clientService;
 
+    // 의뢰인 상세정보
+    @GetMapping("/{clientId}")
+    public ResponseEntity<ClientDto> selectClientDetailInfo(@PathVariable("clientId") Long clientId) {
+        return ResponseEntity.ok(clientService.getClientById(clientId));
+    }
+
     // 의뢰인 등록
     @PostMapping()
     public ResponseEntity<Void> insertClient(@RequestBody @Valid InsertClientForm form) {
@@ -38,24 +40,28 @@ public class ClientController {
         return ResponseEntity.ok().build();
     }
 
+    // 의뢰인 수정
     @PutMapping("/{clientId}")
     public ResponseEntity<Void> updateClientInfo(@PathVariable("clientId") Long clientId, @RequestBody @Valid UpdateClientInfoForm form) {
         clientService.updateClientInfo(clientId, form);
         return ResponseEntity.ok().build();
     }
 
+    // 의뢰인 삭제
     @PatchMapping("/{clientId}")
     public ResponseEntity<Void> deleteClientInfo(@PathVariable("clientId") Long clientId) {
         clientService.deleteClientInfo(clientId);
         return ResponseEntity.ok().build();
     }
 
+    // 의뢰인 목록
     @GetMapping()
     public ResponseEntity<List<ClientDto>> getClientList() {
         return ResponseEntity.ok(clientService.getClientList());
     }
 
-    @GetMapping("/{clientId}")
+    // 의뢰인 사건 리스트, 페이징 정보
+    @GetMapping("/{clientId}/{lawsuitId}")  // url 수정 필요
     public ResponseEntity<ClientLawsuitDto> getClientLawsuitList(
         @PathVariable("clientId") Long clientId,
         @ModelAttribute GetClientLawsuitForm form) {

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
@@ -1,20 +1,27 @@
 package com.avg.lawsuitmanagement.client.controller;
 
+import com.avg.lawsuitmanagement.client.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
 import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
+import com.avg.lawsuitmanagement.client.dto.ClientLawsuitDto;
 import com.avg.lawsuitmanagement.client.service.ClientService;
+import com.avg.lawsuitmanagement.common.util.PagingUtil;
+import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,8 +52,15 @@ public class ClientController {
 
     @GetMapping()
     public ResponseEntity<List<ClientDto>> getClientList() {
-        clientService.getClientList();
         return ResponseEntity.ok(clientService.getClientList());
+    }
+
+    @GetMapping("/{clientId}")
+    public ResponseEntity<ClientLawsuitDto> getClientLawsuitList(
+        @PathVariable("clientId") Long clientId,
+        @ModelAttribute GetClientLawsuitForm form) {
+
+        return ResponseEntity.ok(clientService.getClientLawsuitList(clientId, form));
     }
 }
 

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/form/GetClientLawsuitForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/form/GetClientLawsuitForm.java
@@ -1,0 +1,11 @@
+package com.avg.lawsuitmanagement.client.controller.form;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GetClientLawsuitForm {
+    private int curPage;
+    private int itemsPerPage;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/client/dto/ClientLawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/dto/ClientLawsuitDto.java
@@ -1,0 +1,23 @@
+package com.avg.lawsuitmanagement.client.dto;
+
+import com.avg.lawsuitmanagement.common.util.dto.PageRangeDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ClientLawsuitDto {
+    private List<LawsuitDto> lawsuitList;
+    private PageRangeDto pageRange;
+
+     public static ClientLawsuitDto of (List<LawsuitDto> lawsuitList, PageRangeDto pageRange) {
+         return ClientLawsuitDto.builder()
+            .lawsuitList(lawsuitList)
+            .pageRange(pageRange)
+            .build();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -2,8 +2,10 @@ package com.avg.lawsuitmanagement.client.repository;
 
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
+import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import java.util.HashMap;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -18,4 +20,7 @@ public interface ClientMapperRepository {
     void updateClientInfo(UpdateClientInfoParam param);
     void deleteClientInfo(long clientId);
     List<ClientDto> getClientList();
+    List<LawsuitDto> selectClientLawsuitList(SelectClientLawsuitListParam param);
+    long getLawsuitCountByClientId(long clientId);
+
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/param/SelectClientLawsuitListParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/param/SelectClientLawsuitListParam.java
@@ -1,0 +1,24 @@
+package com.avg.lawsuitmanagement.client.repository.param;
+
+import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class SelectClientLawsuitListParam {
+    private long clientId;
+    private int offset;
+    private int limit;
+
+
+    public static SelectClientLawsuitListParam of(long clientId, PagingDto pagingDto) {
+        return SelectClientLawsuitListParam.builder()
+            .clientId(clientId)
+            .offset(pagingDto.getOffset())
+            .limit(pagingDto.getLimit())
+            .build();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -3,13 +3,20 @@ package com.avg.lawsuitmanagement.client.service;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_ALREADY_EXIST;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_NOT_FOUND;
 
+import com.avg.lawsuitmanagement.client.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
 import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
+import com.avg.lawsuitmanagement.client.dto.ClientLawsuitDto;
 import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
+import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.util.PagingUtil;
+import com.avg.lawsuitmanagement.common.util.dto.PageRangeDto;
+import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,5 +76,28 @@ public class ClientService {
 
     public List<ClientDto> getClientList() {
         return clientMapperRepository.getClientList();
+    }
+
+    public ClientLawsuitDto getClientLawsuitList(long clientId, GetClientLawsuitForm form) {
+        ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
+
+        // 해당 clientId의 의뢰인이 없을 경우
+        if (clientDto == null) {
+            throw new CustomRuntimeException(CLIENT_NOT_FOUND);
+        }
+
+        long total = clientMapperRepository.getLawsuitCountByClientId(clientId);
+
+        PagingDto pagingDto = PagingUtil.calculatePaging(form.getCurPage(), form.getItemsPerPage());
+        SelectClientLawsuitListParam param = SelectClientLawsuitListParam.of(clientId, pagingDto);
+        // 한 페이지에 나타나는 사건 리스트 목록
+        List<LawsuitDto> lawsuitList = clientMapperRepository.selectClientLawsuitList(param);
+
+        // startPage, endPage 저장
+        PageRangeDto pageRangeDto = PagingUtil.calculatePageRange(form.getCurPage(), total);
+
+        // ClientController의 반환값은 List<LawSuitDto>인데 lawsuitList pageRangeDto를 어떻게 넘겨주지?
+        // 다른 Dto를 또 만들어야하나..??
+        return ClientLawsuitDto.of(lawsuitList, pageRangeDto);
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -21,7 +21,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import java.util.HashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -96,8 +95,6 @@ public class ClientService {
         // startPage, endPage 저장
         PageRangeDto pageRangeDto = PagingUtil.calculatePageRange(form.getCurPage(), total);
 
-        // ClientController의 반환값은 List<LawSuitDto>인데 lawsuitList pageRangeDto를 어떻게 넘겨주지?
-        // 다른 Dto를 또 만들어야하나..??
         return ClientLawsuitDto.of(lawsuitList, pageRangeDto);
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/common/util/PagingUtil.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/util/PagingUtil.java
@@ -1,0 +1,28 @@
+package com.avg.lawsuitmanagement.common.util;
+
+import com.avg.lawsuitmanagement.common.util.dto.PageRangeDto;
+import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
+
+public class PagingUtil {
+    // 페이지의 시작 번호와 해당 페이지에 나타낼 글 수
+    public static PagingDto calculatePaging(int curPage, int dataPerPage) {
+        return PagingDto.builder()
+            .offset((curPage-1)*dataPerPage)
+            .limit(dataPerPage)
+            .build();
+    }
+
+    // 현재 선택한 페이지에 따른 시작페이지와 마지막 페이지
+    public static PageRangeDto calculatePageRange(int curPage, long total) {
+        int pageSize = 10;
+        int startPage = ((curPage / pageSize) * pageSize) + 1;
+        int endPage = (startPage - 1) + pageSize;
+        int totalPage = (int) Math.ceil((double) total/pageSize);
+
+        return PageRangeDto.builder()
+            .startPage(startPage)
+            .endPage(Math.min(totalPage, endPage))
+            .build();
+    }
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PageRangeDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PageRangeDto.java
@@ -1,0 +1,13 @@
+package com.avg.lawsuitmanagement.common.util.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class PageRangeDto {
+    private int startPage;
+    private int endPage;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PagingDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PagingDto.java
@@ -1,0 +1,15 @@
+package com.avg.lawsuitmanagement.common.util.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@RequiredArgsConstructor
+public class PagingDto {
+    private int offset; // 시작점
+    private int limit;  // 한 페이지에 나타낼 개수
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
@@ -1,0 +1,24 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@RequiredArgsConstructor
+public class LawsuitDto {
+    private String lawsuit_type;
+    private String name;
+    private int court_id;
+    private int commission_fee;
+    private int contingent_fee;
+    private String lawsuit_status;
+    private String lawsuit_num;
+    private String result;
+    private String judgement_date;
+    private String created_at;
+    private String updated_at;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/token/service/TokenService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/token/service/TokenService.java
@@ -25,7 +25,7 @@ public class TokenService {
     public JwtTokenDto login(LoginForm form) {
 //
 //        UsernamePasswordAuthenticationToken authenticationToken
-//            = new UsernamePasswordAuthenticationToken(userName, form.getPassword());
+//            = new UsernamePasswordAuthenticationToken(userName, repository.getPassword());
 //
 //        Authentication authentication = authenticate(authenticationToken);
 

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -45,4 +45,24 @@
         from client
         where is_deleted = false;
     </select>
+
+    <select id="getLawsuitCountByClientId" parameterType="java.lang.Long" resultType="java.lang.Long">
+        select count(*)
+        from lawsuit l
+                 join lawsuit_client_map map on l.id = map.lawsuit_id
+        where map.client_id = #{clientId}
+          and l.is_deleted = false
+    </select>
+
+    <select id="selectClientLawsuitList" parameterType="SelectClientLawsuitListParam" resultType="LawsuitDto">
+        select l.*
+        from lawsuit l
+                 join lawsuit_client_map map on l.id = map.lawsuit_id
+        where map.client_id = #{clientId}
+          and l.is_deleted = false
+        order by l.created_at desc
+            limit #{limit} offset #{offset}
+    </select>
+
+
 </mapper>


### PR DESCRIPTION
Background
---
사용자는 해당 의뢰인의 사건 목록을 조회할 수 있다.

Change
---
해당 의뢰인의 id(clientId)와 현재 페이지, 한 페이지에 나타낼 데이터 개수를 통해 페이징을 통한 데이터 리스트를 볼 수 있다.
PagingUtil 클래스를 만들어 페이징에 필요한 정보를 계산하는 기능을 다른 곳에서도 공통으로 사용할 수 있도록 만들었다.

Exception
---
해당 의뢰인의 사건 정보를 불러올 때, 해당 의뢰인의 id로 의뢰인 DB에 존재하는지 검사한다.
만약 해당 id의 의뢰인이 없으면 ClientNotFoundException을 발생시킨다.

Discuss
---
의뢰인의 사건정보를 불러올 때, Mapping 되는 경로는 API 설계서 기준으로 /lawsuits/clients/{clientId} 경로입니다.
하지만 의뢰인 상세조회 영역에서 해당 의뢰인의 사건 정보를 불러올 때도 위와 같은 경로로 Mapping해야하는지 의문이었습니다. 따라서 이 부분은 팀원들과 상의 후에 수정할 예정이라 현재는 임시로 /{clientId}/{lawsuitId} 경로로 설정해놓았습니다.