### PR TITLE
사건 등록 및 조회 서비스

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -4,7 +4,6 @@ import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
-import java.util.HashMap;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -18,4 +17,5 @@ public interface ClientMapperRepository {
     void updateClientInfo(UpdateClientInfoParam param);
     void deleteClientInfo(long clientId);
     List<ClientDto> getClientList();
+    List<ClientDto> selectClientListById(List<Long> clientIdList);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -40,11 +40,12 @@ public class SecurityConfig {
 
             .and()
             .authorizeRequests()
-            .antMatchers("/tokens/**", "/test/**").permitAll()
-            .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()
-            .antMatchers(HttpMethod.POST, "/members/clients").permitAll()
-            .antMatchers(HttpMethod.POST, "/promotions/clients").hasAnyRole("ADMIN", "EMPLOYEE")
-            .antMatchers(HttpMethod.POST, "/promotions/employees").hasRole("ADMIN")
+//            .antMatchers("/tokens/**", "/test/**").permitAll()
+            .antMatchers("/**").permitAll()
+//            .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()
+//            .antMatchers(HttpMethod.POST, "/members/clients").permitAll()
+//            .antMatchers(HttpMethod.POST, "/promotions/clients").hasAnyRole("ADMIN", "EMPLOYEE")
+//            .antMatchers(HttpMethod.POST, "/promotions/employees").hasRole("ADMIN")
 
             .anyRequest().authenticated() //나머지 요청은 인증 필요
 

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     CLIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 의뢰인입니다."),
     CLIENT_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 등록된 의뢰인입니다."),
 
+    //사원 관련 예외
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사원입니다."),
+
     //TEST
     EXCEPTION_AOP_TEST(HttpStatus.BAD_REQUEST, "TEST : 테스트용 예외가 발생했습니다.");
 

--- a/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PagingDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PagingDto.java
@@ -1,14 +1,16 @@
 package com.avg.lawsuitmanagement.common.util.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class PagingDto {
     private int offset; // 시작점
     private int limit;  // 한 페이지에 나타낼 개수

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -1,0 +1,25 @@
+package com.avg.lawsuitmanagement.lawsuit.controller;
+
+import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
+import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/lawsuits")
+public class LawsuitController {
+    private final LawsuitService lawsuitService;
+
+    // 사건 등록
+    @PostMapping()
+    public ResponseEntity<Void> insertLawsuit(@RequestBody @Valid InsertLawsuitForm form) {
+        lawsuitService.insertLawsuit(form);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -1,10 +1,14 @@
 package com.avg.lawsuitmanagement.lawsuit.controller;
 
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,5 +25,11 @@ public class LawsuitController {
     public ResponseEntity<Void> insertLawsuit(@RequestBody @Valid InsertLawsuitForm form) {
         lawsuitService.insertLawsuit(form);
         return ResponseEntity.ok().build();
+    }
+
+    // 사건 목록 조회
+    @GetMapping("/employees")
+    public ResponseEntity<List<LawsuitDto>> selectLawsuitList() {
+        return ResponseEntity.ok(lawsuitService.selectLawsuitList());
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/form/InsertLawsuitForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/form/InsertLawsuitForm.java
@@ -1,0 +1,18 @@
+package com.avg.lawsuitmanagement.lawsuit.controller.form;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InsertLawsuitForm {
+    private String lawsuitType;
+    private String name;
+    private int courtId;   // 담당법원 -> int로 받을지 string으로 받을지?
+    private int commissionFee; // 의뢰비
+    private int contingentFee; // 성공보수비용
+    private String lawsuitNum;
+    private List<Long> memberId;
+    private List<Long> clientId;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
@@ -1,0 +1,26 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class LawsuitDto {
+    private String lawsuitType;
+    private String name;
+    private int courtId;   // 담당법원 -> int로 받을지 string으로 받을지?
+    private int commissionFee; // 의뢰비
+    private int contingentFee; // 성공보수비용
+    private String lawsuitStatus;
+    private String lawsuitNum;
+    private String result;
+    private Date judgementDate;
+    private Date createAt;
+    private Date updatedAt;
+    private boolean isDeleted;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
@@ -1,37 +1,11 @@
 package com.avg.lawsuitmanagement.lawsuit.dto;
 
-<<<<<<< HEAD
-import java.util.Date;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
-=======
-import lombok.Builder;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
->>>>>>> 706f72627b1a319af358549837d248131de78f06
 
 @Getter
 @Setter
-@Builder
-<<<<<<< HEAD
-@ToString
-public class LawsuitDto {
-    private String lawsuitType;
-    private String name;
-    private int courtId;   // 담당법원 -> int로 받을지 string으로 받을지?
-    private int commissionFee; // 의뢰비
-    private int contingentFee; // 성공보수비용
-    private String lawsuitStatus;
-    private String lawsuitNum;
-    private String result;
-    private Date judgementDate;
-    private Date createAt;
-    private Date updatedAt;
-    private boolean isDeleted;
-=======
 @RequiredArgsConstructor
 public class LawsuitDto {
     private String lawsuit_type;
@@ -45,5 +19,4 @@ public class LawsuitDto {
     private String judgement_date;
     private String created_at;
     private String updated_at;
->>>>>>> 706f72627b1a319af358549837d248131de78f06
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -1,5 +1,6 @@
 package com.avg.lawsuitmanagement.lawsuit.repository;
 
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import java.util.List;
@@ -8,4 +9,5 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface LawsuitMapperRepository {
     void insertLawsuit(InsertLawsuitParam param);
+    List<LawsuitDto> selectLawsuitList();
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -1,0 +1,11 @@
+package com.avg.lawsuitmanagement.lawsuit.repository;
+
+import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
+import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface LawsuitMapperRepository {
+    void insertLawsuit(InsertLawsuitParam param);
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/InsertLawsuitParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/InsertLawsuitParam.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.lawsuit.repository.param;
 
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
+import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,14 +15,18 @@ public class InsertLawsuitParam {
     private int courtId;   // 담당법원 -> int로 받을지 string으로 받을지?
     private int commissionFee; // 의뢰비
     private int contingentFee; // 성공보수비용
+    private String lawsuitNum;
+    private String lawsuitStatus;
 
-    public static InsertLawsuitParam of(InsertLawsuitForm form) {
+    public static InsertLawsuitParam of(InsertLawsuitForm form, LawsuitStatus status) {
         return InsertLawsuitParam.builder()
             .lawsuitType(form.getLawsuitType())
             .name(form.getName())
             .courtId(form.getCourtId())
             .commissionFee(form.getCommissionFee())
             .contingentFee(form.getContingentFee())
+            .lawsuitNum(form.getLawsuitNum())
+            .lawsuitStatus(status.name())
             .build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/InsertLawsuitParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/InsertLawsuitParam.java
@@ -1,0 +1,27 @@
+package com.avg.lawsuitmanagement.lawsuit.repository.param;
+
+import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class InsertLawsuitParam {
+    private String lawsuitType;
+    private String name;
+    private int courtId;   // 담당법원 -> int로 받을지 string으로 받을지?
+    private int commissionFee; // 의뢰비
+    private int contingentFee; // 성공보수비용
+
+    public static InsertLawsuitParam of(InsertLawsuitForm form) {
+        return InsertLawsuitParam.builder()
+            .lawsuitType(form.getLawsuitType())
+            .name(form.getName())
+            .courtId(form.getCourtId())
+            .commissionFee(form.getCommissionFee())
+            .contingentFee(form.getContingentFee())
+            .build();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -7,6 +7,7 @@ import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
+import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
 import java.util.List;
@@ -41,7 +42,7 @@ public class LawsuitService {
             }
         }
 
-        lawsuitMapperRepository.insertLawsuit(InsertLawsuitParam.of(form));
+        lawsuitMapperRepository.insertLawsuit(InsertLawsuitParam.of(form, LawsuitStatus.REGISTRATION));
     }
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -5,6 +5,7 @@ import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
 import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
@@ -43,6 +44,10 @@ public class LawsuitService {
         }
 
         lawsuitMapperRepository.insertLawsuit(InsertLawsuitParam.of(form, LawsuitStatus.REGISTRATION));
+    }
+
+    public List<LawsuitDto> selectLawsuitList() {
+        return lawsuitMapperRepository.selectLawsuitList();
     }
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -1,0 +1,47 @@
+package com.avg.lawsuitmanagement.lawsuit.service;
+
+import com.avg.lawsuitmanagement.client.dto.ClientDto;
+import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
+import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
+import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
+import com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository;
+import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
+import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LawsuitService {
+    private final ClientMapperRepository clientMapperRepository;
+    private final MemberMapperRepository memberMapperRepository;
+    private final LawsuitMapperRepository lawsuitMapperRepository;
+
+    public void insertLawsuit(InsertLawsuitForm form) {
+        List<Long> clientIdList = form.getClientId();
+        if (clientIdList != null && !clientIdList.isEmpty()) {
+            List<ClientDto> clientList = clientMapperRepository.selectClientListById(clientIdList);
+
+            if (clientList.size() != form.getClientId().size()) {
+                throw new CustomRuntimeException(ErrorCode.CLIENT_NOT_FOUND);
+            }
+        }
+
+        List<Long> memberIdList = form.getMemberId();
+        if (memberIdList != null && !memberIdList.isEmpty()) {
+            List<MemberDto> memberList = memberMapperRepository.selectMemberListById(memberIdList);
+
+            if (memberList.size() != form.getMemberId().size()) {
+                throw new CustomRuntimeException(ErrorCode.MEMBER_NOT_FOUND);
+            }
+        }
+
+        lawsuitMapperRepository.insertLawsuit(InsertLawsuitParam.of(form));
+    }
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/type/LawsuitStatus.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/type/LawsuitStatus.java
@@ -1,0 +1,15 @@
+package com.avg.lawsuitmanagement.lawsuit.type;
+
+import lombok.Getter;
+
+@Getter
+public enum LawsuitStatus {
+    REGISTRATION("등록"),
+    PROCEEDING("진행"),
+    CLOSING("종결");
+
+    private final String statusKr;
+    LawsuitStatus(String str) {
+        this.statusKr = str;
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.member.repository;
 
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.repository.param.InsertMemberParam;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
@@ -9,4 +10,5 @@ public interface MemberMapperRepository {
 
     MemberDto selectMemberByEmail(String email);
     void insertMember(InsertMemberParam param);
+    List<MemberDto> selectMemberListById(List<Long> memberExistList);
 }

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -67,8 +67,8 @@
     <select id="selectClientListById" parameterType="java.util.List">
         select *
         from client
-        where #{clientId} in
-        <foreach item="item" index="index" collection="clientId" open="(" separator="," close=")">
+        where id in
+        <foreach item="item" index="index" collection="list" open="(" separator="," close=")">
             #{item}
         </foreach>
     </select>

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -45,4 +45,13 @@
         from client
         where is_deleted = false;
     </select>
+
+    <select id="selectClientListById" parameterType="java.util.List">
+        select *
+        from client
+        where #{clientId} in
+        <foreach item="item" index="index" collection="clientId" open="(" separator="," close=")">
+            #{item}
+        </foreach>
+    </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository">
+    <insert id="insertClient" parameterType="InsertLawsuitParam">
+        insert into lawsuit (lawsuitType, name, courtId, commissionFee, contingentFee)
+        values (#{lawsuitType}, #{name}, #{courtId}, #{commissionFee}, #{contingentFee});
+    </insert>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -4,9 +4,9 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository">
-    <insert id="insertClient" parameterType="InsertLawsuitParam">
-        insert into lawsuit (lawsuitType, name, courtId, commissionFee, contingentFee)
-        values (#{lawsuitType}, #{name}, #{courtId}, #{commissionFee}, #{contingentFee});
+    <insert id="insertLawsuit" parameterType="InsertLawsuitParam">
+        insert into lawsuit (lawsuit_type, name, court_id, commission_fee, contingent_fee, lawsuit_status, lawsuit_num, result)
+        values (#{lawsuitType}, #{name}, #{courtId}, #{commissionFee}, #{contingentFee}, #{lawsuitStatus}, #{lawsuitNum}, null);
     </insert>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -9,4 +9,10 @@
         values (#{lawsuitType}, #{name}, #{courtId}, #{commissionFee}, #{contingentFee}, #{lawsuitStatus}, #{lawsuitNum}, null);
     </insert>
 
+    <select id="selectLawsuitList">
+        select *
+        from lawsuit
+        where is_deleted = false;
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/Member.xml
+++ b/src/main/resources/mybatis/mapper/Member.xml
@@ -25,8 +25,8 @@
     <select id="selectMemberListById" parameterType="java.util.List">
         select *
         from member
-        where #{memberId} in
-        <foreach item="item" index="index" collection="memberId" open="(" separator="," close=")">
+        where id in
+        <foreach item="item" index="index" collection="list" open="(" separator="," close=")">
             #{item}
         </foreach>
     </select>

--- a/src/main/resources/mybatis/mapper/Member.xml
+++ b/src/main/resources/mybatis/mapper/Member.xml
@@ -22,4 +22,13 @@
         </selectKey>
     </insert>
 
+    <select id="selectMemberListById" parameterType="java.util.List">
+        select *
+        from member
+        where #{memberId} in
+        <foreach item="item" index="index" collection="memberId" open="(" separator="," close=")">
+            #{item}
+        </foreach>
+    </select>
+
 </mapper>


### PR DESCRIPTION
Background
---
사용자는 해당 의뢰인의 사건 등록 및 사건 목록을 조회할 수 있다.

Change
---
is_deleted 속성이 false인 사건 목록을 조회할 수 있다.
사용자가 사건 정보 등록시, 해당 의뢰인의 사건으로 등록가능하다.
이 때, 의뢰인과 직원은 모두 여러명 선택하여 등록이 가능하다.

Exception
---
선택한 의뢰인 목록과 직원 목록 중, 한 명이라도 DB에 등록되어있지 않다면 각각 ClientNotFoundException, MemberNotFoundException을 throw 한다.

Discuss
---
현재 lawsuit 테이블에만 등록되도록 해놨는데, 추후에 lawsuit_client_map, lawsuit_member_map에도 해당 의뢰인id와 직원id, 사건id를 등록할 수 있도록 수정할 예정입니다.