### PR TITLE
fix: 사건 상태 enum으로 관리 및 LawsuitDto 사건 id 추가

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 
     //사건 관련 예외
     LAWSUIT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사건입니다."),
+    LAWSUIT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상태입니다."),
 
     //직책, 역할, 법원
     HIERARCHY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 직책입니다."),

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Setter
 @RequiredArgsConstructor
 public class LawsuitDto {
+    private Long id;
     private String lawsuit_type;
     private String name;
     private int court_id;

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/UpdateLawsuitInfoParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/UpdateLawsuitInfoParam.java
@@ -3,6 +3,7 @@ package com.avg.lawsuitmanagement.lawsuit.repository.param;
 import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
+import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import java.util.Date;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public class UpdateLawsuitInfoParam {
     private String result;
     private Date judgement_date;
 
-    public static UpdateLawsuitInfoParam of(Long lawsuitId, UpdateLawsuitInfoForm form) {
+    public static UpdateLawsuitInfoParam of(Long lawsuitId, UpdateLawsuitInfoForm form, LawsuitStatus status) {
         return UpdateLawsuitInfoParam.builder()
             .lawsuitId(lawsuitId)
             .lawsuit_type(form.getLawsuit_type())
@@ -31,7 +32,7 @@ public class UpdateLawsuitInfoParam {
             .court_id(form.getCourt_id())
             .commission_fee(form.getCommission_fee())
             .contingent_fee(form.getContingent_fee())
-            .lawsuit_status(form.getLawsuit_status())
+            .lawsuit_status(status.name())
             .lawsuit_num(form.getLawsuit_num())
             .result(form.getResult())
             .judgement_date(form.getJudgement_date())

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.lawsuit.service;
 
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.LAWSUIT_NOT_FOUND;
+import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.LAWSUIT_STATUS_NOT_FOUND;
 
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
@@ -57,12 +58,24 @@ public class LawsuitService {
     public void updateLawsuitInfo(long lawsuitId, UpdateLawsuitInfoForm form) {
         LawsuitDto lawsuitDto = lawsuitMapperRepository.selectLawsuitById(lawsuitId);
         
-        // lawsuitId에 해당하는 사건이 없다면 
+        // lawsuitId에 해당하는 사건이 없다면
         if (lawsuitDto == null) {
             throw new CustomRuntimeException(LAWSUIT_NOT_FOUND);
         }
 
-        lawsuitMapperRepository.updateLawsuitInfo(UpdateLawsuitInfoParam.of(lawsuitId, form));
+        // 클라이언트에서 받아온 사건상태 정보를 enum 클래스의 사건 상태들과 비교
+        LawsuitStatus lawsuitStatus = null;
+        for (LawsuitStatus status : LawsuitStatus.values()) {
+            if (status.getStatusKr().equals(form.getLawsuit_status())) {
+                lawsuitStatus = status;
+            }
+        }
+
+        if (lawsuitStatus == null) {
+            throw new CustomRuntimeException(LAWSUIT_STATUS_NOT_FOUND);
+        }
+
+        lawsuitMapperRepository.updateLawsuitInfo(UpdateLawsuitInfoParam.of(lawsuitId, form, lawsuitStatus));
     }
 
 }


### PR DESCRIPTION
Background
---
기존 코드는 사건 상태를 문자열로 받아와 DB에 입력되는 방식으로 작성하였다.

Change
---
해당 문자열을 받아와 enum 클래스인 LawsuitStatus의 enum들과 비교해 값이 동일한 enum을 불러와 Param으로 전달하도록 수정했다.

Exception
---

입력된 문자열 값과 동일한 enum이 없다면 LawsuitStatusNotFound를 throw한다.

Test
---
postman으로 테스트 완료