### PR TITLE
fix: 사건 등록 서비스 수정

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/ClientController.java
@@ -59,14 +59,5 @@ public class ClientController {
     public ResponseEntity<List<ClientDto>> selectClientList() {
         return ResponseEntity.ok(clientService.selectClientList());
     }
-
-    // 의뢰인 사건 리스트, 페이징 정보
-    @GetMapping("/{clientId}/{lawsuitId}")  // url 수정 필요
-    public ResponseEntity<ClientLawsuitDto> selectClientLawsuitList(
-        @PathVariable("clientId") Long clientId,
-        @ModelAttribute GetClientLawsuitForm form) {
-
-        return ResponseEntity.ok(clientService.selectClientLawsuitList(clientId, form));
-    }
 }
 

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -20,7 +20,6 @@ public interface ClientMapperRepository {
     void updateClientInfo(UpdateClientInfoParam param);
     void deleteClientInfo(long clientId);
     List<ClientDto> selectClientList();
-    List<LawsuitDto> selectClientLawsuitList(SelectClientLawsuitListParam param);
     long getLawsuitCountByClientId(long clientId);
     List<ClientDto> selectClientListById(List<Long> clientIdList);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -76,25 +76,4 @@ public class ClientService {
     public List<ClientDto> selectClientList() {
         return clientMapperRepository.selectClientList();
     }
-
-    public ClientLawsuitDto selectClientLawsuitList(long clientId, GetClientLawsuitForm form) {
-        ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
-
-        // 해당 clientId의 의뢰인이 없을 경우
-        if (clientDto == null) {
-            throw new CustomRuntimeException(CLIENT_NOT_FOUND);
-        }
-
-        long total = clientMapperRepository.getLawsuitCountByClientId(clientId);
-
-        PagingDto pagingDto = PagingUtil.calculatePaging(form.getCurPage(), form.getItemsPerPage());
-        SelectClientLawsuitListParam param = SelectClientLawsuitListParam.of(clientId, pagingDto);
-        // 한 페이지에 나타나는 사건 리스트 목록
-        List<LawsuitDto> lawsuitList = clientMapperRepository.selectClientLawsuitList(param);
-
-        // startPage, endPage 저장
-        PageRangeDto pageRangeDto = PagingUtil.calculatePageRange(form.getCurPage(), total);
-
-        return ClientLawsuitDto.of(lawsuitList, pageRangeDto);
-    }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -1,5 +1,8 @@
 package com.avg.lawsuitmanagement.lawsuit.controller;
 
+import com.avg.lawsuitmanagement.client.controller.form.GetClientLawsuitForm;
+import com.avg.lawsuitmanagement.client.dto.ClientLawsuitDto;
+import com.avg.lawsuitmanagement.client.service.ClientService;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
@@ -10,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,7 +26,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/lawsuits")
 public class LawsuitController {
     private final LawsuitService lawsuitService;
+    private final ClientService clientService;
 
+    // 의뢰인 사건 리스트, 페이징 정보
+    @GetMapping("/{clientId}")  // url 수정 필요
+    public ResponseEntity<ClientLawsuitDto> selectClientLawsuitList(
+        @PathVariable("clientId") Long clientId,
+        @ModelAttribute GetClientLawsuitForm form) {
+
+        return ResponseEntity.ok(lawsuitService.selectClientLawsuitList(clientId, form));
+    }
     // 사건 등록
     @PostMapping()
     public ResponseEntity<Void> insertLawsuit(@RequestBody @Valid InsertLawsuitForm form) {

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -1,16 +1,21 @@
 package com.avg.lawsuitmanagement.lawsuit.repository;
 
+import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
+import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitClientMemberIdParam;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.UpdateLawsuitInfoParam;
-import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface LawsuitMapperRepository {
+    List<LawsuitDto> selectClientLawsuitList(SelectClientLawsuitListParam param);
     LawsuitDto selectLawsuitById(long lawsuitId);
     void insertLawsuit(InsertLawsuitParam param);
+    Long getLastInsertedLawsuitId();
+    void insertLawsuitClientMap(InsertLawsuitClientMemberIdParam param);
+    void insertLawsuitMemberMap(InsertLawsuitClientMemberIdParam param);
     List<LawsuitDto> selectLawsuitList();
     void updateLawsuitInfo(UpdateLawsuitInfoParam param);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/InsertLawsuitClientMemberIdParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/InsertLawsuitClientMemberIdParam.java
@@ -1,0 +1,24 @@
+package com.avg.lawsuitmanagement.lawsuit.repository.param;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class InsertLawsuitClientMemberIdParam {
+    private Long lawsuitId;
+    private List<Long> clientId;
+    private List<Long> memberId;
+
+    public static InsertLawsuitClientMemberIdParam of(long lawsuitId, List<Long> clientIdList, List<Long> memberIdList) {
+        return InsertLawsuitClientMemberIdParam.builder()
+            .lawsuitId(lawsuitId)
+            .clientId(clientIdList)
+            .memberId(memberIdList)
+            .build();
+    }
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.lawsuit.service;
 
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_NOT_FOUND;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.LAWSUIT_NOT_FOUND;
+import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.avg.lawsuitmanagement.client.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
@@ -9,7 +10,6 @@ import com.avg.lawsuitmanagement.client.dto.ClientLawsuitDto;
 import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
-import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import com.avg.lawsuitmanagement.common.util.PagingUtil;
 import com.avg.lawsuitmanagement.common.util.dto.PageRangeDto;
 import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
@@ -67,7 +67,7 @@ public class LawsuitService {
             List<ClientDto> clientList = clientMapperRepository.selectClientListById(clientIdList);
 
             if (clientList.size() != form.getClientId().size()) {
-                throw new CustomRuntimeException(ErrorCode.CLIENT_NOT_FOUND);
+                throw new CustomRuntimeException(CLIENT_NOT_FOUND);
             }
         }
 
@@ -77,13 +77,19 @@ public class LawsuitService {
             List<MemberDto> memberList = memberMapperRepository.selectMemberListById(memberIdList);
 
             if (memberList.size() != form.getMemberId().size()) {
-                throw new CustomRuntimeException(ErrorCode.MEMBER_NOT_FOUND);
+                throw new CustomRuntimeException(MEMBER_NOT_FOUND);
             }
         }
         lawsuitMapperRepository.insertLawsuit(InsertLawsuitParam.of(form, LawsuitStatus.REGISTRATION));
 
         // 등록한 사건의 id값
         long lawsuitId = lawsuitMapperRepository.getLastInsertedLawsuitId();
+        LawsuitDto lawsuitDto = lawsuitMapperRepository.selectLawsuitById(lawsuitId);
+
+        // 사건 id에 해당하는 사건이 없을 경우
+        if (lawsuitDto == null) {
+            throw new CustomRuntimeException(LAWSUIT_NOT_FOUND);
+        }
 
         lawsuitMapperRepository.insertLawsuitClientMap(
             InsertLawsuitClientMemberIdParam.of(lawsuitId, clientIdList, memberIdList));

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -54,16 +54,6 @@
           and l.is_deleted = false
     </select>
 
-    <select id="selectClientLawsuitList" parameterType="SelectClientLawsuitListParam" resultType="LawsuitDto">
-        select l.*
-        from lawsuit l
-                 join lawsuit_client_map map on l.id = map.lawsuit_id
-        where map.client_id = #{clientId}
-          and l.is_deleted = false
-        order by l.created_at desc
-            limit #{limit} offset #{offset}
-    </select>
-
     <select id="selectClientListById" parameterType="java.util.List">
         select *
         from client

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -4,6 +4,17 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository">
+
+    <select id="selectClientLawsuitList" parameterType="SelectClientLawsuitListParam" resultType="LawsuitDto">
+        select l.*
+        from lawsuit l
+                 join lawsuit_client_map map on l.id = map.lawsuit_id
+        where map.client_id = #{clientId}
+          and l.is_deleted = false
+        order by l.created_at desc
+        limit #{limit} offset #{offset}
+    </select>
+
     <select id="selectLawsuitById" parameterType="java.lang.Long">
         select *
         from lawsuit
@@ -13,6 +24,29 @@
     <insert id="insertLawsuit" parameterType="InsertLawsuitParam">
         insert into lawsuit (lawsuit_type, name, court_id, commission_fee, contingent_fee, lawsuit_status, lawsuit_num, result)
         values (#{lawsuitType}, #{name}, #{courtId}, #{commissionFee}, #{contingentFee}, #{lawsuitStatus}, #{lawsuitNum}, null);
+    </insert>
+
+    <!-- 추가한 데이터의 id 값을 가져옴 -->
+    <select id="getLastInsertedLawsuitId" resultType="java.lang.Long">
+        SELECT LAST_INSERT_ID();
+    </select>
+
+    <!-- lawsuit_client_map 테이블에 데이터 추가 -->
+    <insert id="insertLawsuitClientMap" parameterType="InsertLawsuitClientMemberIdParam">
+        INSERT INTO lawsuit_client_map (lawsuit_id, client_id)
+        VALUES
+        <foreach item="clientId" collection="clientId" separator=",">
+            (#{lawsuitId}, #{clientId})
+        </foreach>
+    </insert>
+
+    <!-- lawsuit_member_map 테이블에 데이터 추가 -->
+    <insert id="insertLawsuitMemberMap" parameterType="InsertLawsuitClientMemberIdParam">
+        INSERT INTO lawsuit_member_map (lawsuit_id, member_id)
+        VALUES
+        <foreach item="memberId" collection="memberId" separator=",">
+            (#{lawsuitId}, #{memberId})
+        </foreach>
     </insert>
 
     <select id="selectLawsuitList">


### PR DESCRIPTION
Background
---
사건 등록시 '사건-의뢰인' 테이블과 '사건-회원' 테이블에도 각각의 id를 추가해줘야 한다.

Change
---
Mapping URL을 '/clients/{clientId}/{lawsuitId}'에서 '/lawsuits/{clientId}'로 변경
등록한 사건의 id값과 의뢰인 리스트, 회원 리스트를 클라이언트로 부터 받아 '사건-의뢰인' 테이블과 '사건-회원' 테이블에 사건id, 의뢰인 id, 회원 id를 추가할 수 있도록 변경하였다.

하나의 서비스가 여러가지 Repository를 의존하기 때문에 @Transactional 어노테이션을 통해 테이블 하나라도 데이터가 안들어가면 모두 Rollback 되도록 구현하였다.

Exception
---
의뢰인 리스트 : 의뢰인 리스트 중 DB에 한 명이라도 데이터가 없으면 ClientNotFoundException을 throw 한다.
회원 리스트 : 회원 리스트 중 DB에 한 명이라도 데이터가 없으면 MemberNotFoundException을 throw 한다.
사건 : 사건 id에 해당하는 데이터가 DB에 존재하지 않으면 LawsuitNotFoundException을 throw 한다.

Test
---
postman을 통한 테스트 완료