### PR TITLE
feat: 사건 삭제 서비스 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 
     //사원 관련 예외
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사원입니다."),
+    MEMBER_NOT_ASSIGNED_TO_LAWSUIT(HttpStatus.NOT_FOUND, "해당 사건을 담당하는 사원이 아닙니다."),
 
     //사건 관련 예외
     LAWSUIT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사건입니다."),

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -14,6 +14,7 @@ import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -57,5 +58,10 @@ public class LawsuitController {
     }
 
     // 사건 삭제
+    @PatchMapping("/{lawsuitId}")
+    public ResponseEntity<Void> deleteLawsuitInfo(@PathVariable("lawsuitId") Long lawsuitId) {
+        lawsuitService.deleteLawsuitInfo(lawsuitId);
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -29,7 +29,7 @@ public class LawsuitController {
     private final ClientService clientService;
 
     // 의뢰인 사건 리스트, 페이징 정보
-    @GetMapping("/{clientId}")  // url 수정 필요
+    @GetMapping("/clients/{clientId}")  // url 수정 필요
     public ResponseEntity<ClientLawsuitDto> selectClientLawsuitList(
         @PathVariable("clientId") Long clientId,
         @ModelAttribute GetClientLawsuitForm form) {
@@ -55,4 +55,7 @@ public class LawsuitController {
         lawsuitService.updateLawsuitInfo(lawsuitId, form);
         return ResponseEntity.ok().build();
     }
+
+    // 사건 삭제
+
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -18,4 +18,9 @@ public interface LawsuitMapperRepository {
     void insertLawsuitMemberMap(InsertLawsuitClientMemberIdParam param);
     List<LawsuitDto> selectLawsuitList();
     void updateLawsuitInfo(UpdateLawsuitInfoParam param);
+    List<Long> selectMemberByLawsuitId(long lawsuitId);
+    void deleteLawsuitInfo(long lawsuitId);
+    void deleteLawsuitClientMap(long lawsuitId);
+    void deleteLawsuitMemberMap(long lawsuitId);
+
 }

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -64,4 +64,28 @@
         where id = #{lawsuitId};
     </update>
 
+    <select id="selectMemberByLawsuitId" parameterType="java.lang.Long">
+        select member_id
+        from lawsuit_member_map
+        where lawsuit_id = #{lawsuitId};
+    </select>
+
+    <update id="deleteLawsuitInfo" parameterType="java.lang.Long">
+        update lawsuit
+        set is_deleted = true
+        where id = #{lawsuitId};
+    </update>
+
+    <update id="deleteLawsuitClientMap" parameterType="java.lang.Long">
+        update lawsuit_client_map
+        set is_deleted = true
+        where lawsuit_id = #{lawsuitId};
+    </update>
+
+    <update id="deleteLawsuitMemberMap" parameterType="java.lang.Long">
+        update lawsuit_member_map
+        set is_deleted = true
+        where lawsuit_id = #{lawsuitId};
+    </update>
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -28,13 +28,13 @@
 
     <!-- 추가한 데이터의 id 값을 가져옴 -->
     <select id="getLastInsertedLawsuitId" resultType="java.lang.Long">
-        SELECT LAST_INSERT_ID();
+        select LAST_INSERT_ID();
     </select>
 
     <!-- lawsuit_client_map 테이블에 데이터 추가 -->
     <insert id="insertLawsuitClientMap" parameterType="InsertLawsuitClientMemberIdParam">
-        INSERT INTO lawsuit_client_map (lawsuit_id, client_id)
-        VALUES
+        insert into lawsuit_client_map (lawsuit_id, client_id)
+        values
         <foreach item="clientId" collection="clientId" separator=",">
             (#{lawsuitId}, #{clientId})
         </foreach>
@@ -42,8 +42,8 @@
 
     <!-- lawsuit_member_map 테이블에 데이터 추가 -->
     <insert id="insertLawsuitMemberMap" parameterType="InsertLawsuitClientMemberIdParam">
-        INSERT INTO lawsuit_member_map (lawsuit_id, member_id)
-        VALUES
+        insert into lawsuit_member_map (lawsuit_id, member_id)
+        values
         <foreach item="memberId" collection="memberId" separator=",">
             (#{lawsuitId}, #{memberId})
         </foreach>


### PR DESCRIPTION
Background
---
해당 사건의 담당자는 사건을 삭제할 수 있다.

Change
---
클라이언트로 부터 등록한 사건의 id값을 받아 사건 테이블에서 is_deleted 속성을 true로 변경하고, 
'사건-의뢰인' 테이블과 '사건-회원' 테이블에서도 해당 사건 id에 해당하는 is_deleted 속성을 true로 변경하도록 구현했다.

사건 수정과 마찬가지로 하나의 서비스가 여러가지 테이블을 의존하기 때문에 @Transactional 어노테이션을 통해 테이블 하나라도 데이터 삭제가 안되면 모두 Rollback 되도록 구현하였다.

Exception
---
해당 사건을 삭제하려 할 때, 두 가지 예외 처리를 하도록 했다.

1. 해당 사건 id에 해당하는 사건이 DB에 존재하지 않는다면 LawsuitNotFoundException을 throw 한다.
2. 해당 사건의 담당자가 아니라면 MemberNotAssignedToLawsuitException을 throw 한다.

사건을 삭제하기 위해선 로그인을 해야하는데, MemberService의 getLoginMemberInfo()를 의존하여 현재 로그인되어 있는 회원의 정보를 가져오고, 해당 사건을 담당하는 회원 리스트에 존재하는지 확인 후 예외처리를 한다.

Test
---
postman을 통한 테스트 완료