### PR TITLE
의뢰인 삭제 서비스 수정

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/client/dto/ClientLawsuitCountDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/dto/ClientLawsuitCountDto.java
@@ -1,0 +1,15 @@
+package com.avg.lawsuitmanagement.client.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class ClientLawsuitCountDto {
+    private long lawsuitId;
+    private int clientLawsuitCount;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -1,5 +1,6 @@
 package com.avg.lawsuitmanagement.lawsuit.repository;
 
+import com.avg.lawsuitmanagement.client.dto.ClientLawsuitCountDto;
 import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitClientMemberIdParam;
@@ -22,5 +23,7 @@ public interface LawsuitMapperRepository {
     void deleteLawsuitInfo(long lawsuitId);
     void deleteLawsuitClientMap(long lawsuitId);
     void deleteLawsuitMemberMap(long lawsuitId);
+    void deleteLawsuitClientMapByClientId(long clientId);
+    List<ClientLawsuitCountDto> selectLawsuitCountByClientId(long clientId);
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -13,6 +13,7 @@ import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.util.PagingUtil;
+import com.avg.lawsuitmanagement.common.util.SecurityUtil;
 import com.avg.lawsuitmanagement.common.util.dto.PageRangeDto;
 import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
@@ -25,8 +26,6 @@ import com.avg.lawsuitmanagement.lawsuit.repository.param.UpdateLawsuitInfoParam
 import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
-import com.avg.lawsuitmanagement.member.service.MemberService;
-import java.lang.reflect.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +39,6 @@ public class LawsuitService {
     private final ClientMapperRepository clientMapperRepository;
     private final MemberMapperRepository memberMapperRepository;
     private final LawsuitMapperRepository lawsuitMapperRepository;
-    private final MemberService memberService;
 
     public ClientLawsuitDto selectClientLawsuitList(long clientId, GetClientLawsuitForm form) {
         ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
@@ -140,7 +138,8 @@ public class LawsuitService {
         }
 
         // 해당 사건의 담당자가 아니라면
-        MemberDto loginMemberInfo = memberService.getLoginMemberInfo();
+        String email = SecurityUtil.getCurrentLoginEmail();
+        MemberDto loginMemberInfo = memberMapperRepository.selectMemberByEmail(email);
 
         List<Long> memberIdList = lawsuitMapperRepository.selectMemberByLawsuitId(lawsuitId);
         if (!memberIdList.contains(loginMemberInfo.getId())) {

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -88,4 +88,19 @@
         where lawsuit_id = #{lawsuitId};
     </update>
 
+    <!-- cliendId가 속한 사건별 의뢰인 수 -->
+    <select id="selectLawsuitCountByClientId" parameterType="java.lang.Long">
+        select lcm1.lawsuit_id, count(*)
+        from lawsuit_client_map lcm1
+                 join lawsuit_client_map lcm2 on lcm1.lawsuit_id = lcm2.lawsuit_id
+        where lcm1.is_deleted = false and lcm1.client_id = #{clientId}
+        group by lcm1.lawsuit_id;
+    </select>
+
+    <!-- '사건-의뢰인' 매핑 테이블에서 해당 의뢰인 정보 삭제 -->
+    <update id="deleteLawsuitClientMapByClientId" parameterType="java.lang.Long">
+        update lawsuit_client_map
+        set is_deleted = true
+        where client_id = #{clientId};
+    </update>
 </mapper>


### PR DESCRIPTION
Background
---
삭제할 의뢰인이 어떤 사건의 의뢰인일 경우 해당 사건의 의뢰인에서 제외되어야 한다.

만약 삭제할 의뢰인이 어떤 사건의 단일 의뢰인일 경우 사건과 함께 삭제되어야 한다.
어떤 사건에 등록된 여러 명의 의뢰인 중 한명의 의뢰인이라면 해당 사건의 의뢰인에서 제외될 뿐, 사건에는 영향을 미치지 않는다.

Change
---
의뢰인 삭제시, 해당 의뢰인의 사건 목록과 해당 사건에 등록된 각각의 의뢰인 수를 조회하여 해당 사건에 등록된 의뢰인 수에 따라 다른 테이블에도 데이터가 삭제되도록 수정

- 삭제할 의뢰인이 단일 의뢰인일 경우
'의뢰인' 테이블의 의뢰인 삭제
'사건-의뢰인' 테이블의 해당 의뢰인 튜플 삭제
'사건' 테이블의 해당 의뢰인의 사건 튜플 삭제
'사건-회원' 테이블의 사건 튜플 삭제

- 어떤 사건에 등록된 여러 명의 의뢰인 중 한명의 의뢰인일 경우
'의뢰인' 테이블의 의뢰인 삭제
'사건-의뢰인' 테이블의 해당 의뢰인 튜플 삭제

Test
---
postman을 통한 테스트 완료