### PR TITLE
의뢰인별 사건 목록 조회 서비스 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -2,7 +2,6 @@ package com.avg.lawsuitmanagement.lawsuit.controller;
 
 import com.avg.lawsuitmanagement.client.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.client.dto.ClientLawsuitDto;
-import com.avg.lawsuitmanagement.client.service.ClientService;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
@@ -10,7 +9,6 @@ import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -27,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/lawsuits")
 public class LawsuitController {
     private final LawsuitService lawsuitService;
-    private final ClientService clientService;
 
     // 의뢰인 사건 리스트, 페이징 정보
     @GetMapping("/clients/{clientId}")  // url 수정 필요
@@ -37,6 +34,7 @@ public class LawsuitController {
 
         return ResponseEntity.ok(lawsuitService.selectClientLawsuitList(clientId, form));
     }
+
     // 사건 등록
     @PostMapping()
     public ResponseEntity<Void> insertLawsuit(@RequestBody @Valid InsertLawsuitForm form) {
@@ -48,6 +46,12 @@ public class LawsuitController {
     @GetMapping("/employees")
     public ResponseEntity<List<LawsuitDto>> selectLawsuitList() {
         return ResponseEntity.ok(lawsuitService.selectLawsuitList());
+    }
+
+    // 의뢰인에 대한 사건 조회
+    @GetMapping("/{clientId}")
+    public ResponseEntity<List<LawsuitDto>> selectLawsuitByClientId(@PathVariable("clientId") Long clientId) {
+        return ResponseEntity.ok(lawsuitService.selectLawsuitByClientId(clientId));
     }
 
     // 사건 수정

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitDto.java
@@ -9,15 +9,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LawsuitDto {
     private Long id;
-    private String lawsuit_type;
+    private String lawsuitType;
     private String name;
-    private int court_id;
-    private int commission_fee;
-    private int contingent_fee;
-    private String lawsuit_status;
-    private String lawsuit_num;
+    private int courtId;
+    private int commissionFee;
+    private int contingentFee;
+    private String lawsuitStatus;
+    private String lawsuitNum;
     private String result;
-    private String judgement_date;
-    private String created_at;
-    private String updated_at;
+    private String judgementDate;
+    private String createdAt;
+    private String updatedAt;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -25,5 +25,6 @@ public interface LawsuitMapperRepository {
     void deleteLawsuitMemberMap(long lawsuitId);
     void deleteLawsuitClientMapByClientId(long clientId);
     List<ClientLawsuitCountDto> selectLawsuitCountByClientId(long clientId);
+    List<LawsuitDto> selectLawsuitByClientId(long clientId);
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -150,4 +150,15 @@ public class LawsuitService {
         lawsuitMapperRepository.deleteLawsuitClientMap(lawsuitId);
         lawsuitMapperRepository.deleteLawsuitMemberMap(lawsuitId);
     }
+
+    // 해당 의뢰인에 대한 사건 조회
+    public List<LawsuitDto> selectLawsuitByClientId(long clientId) {
+        ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
+
+        if (clientDto == null) {
+            throw new CustomRuntimeException(CLIENT_NOT_FOUND);
+        }
+
+        return lawsuitMapperRepository.selectLawsuitByClientId(clientId);
+    }
 }

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -103,4 +103,15 @@
         set is_deleted = true
         where client_id = #{clientId};
     </update>
+
+    <!-- 의뢰인에 대한 사건 조회 -->
+    <select id="selectLawsuitByClientId" parameterType="java.lang.Long">
+        select *
+        from lawsuit
+        where id in (
+            select lawsuit_id
+            from lawsuit_client_map
+            where lawsuit.is_deleted = false and client_id = #{clientId}
+            );
+    </select>
 </mapper>


### PR DESCRIPTION
Background
---
의뢰인별 등록된 사건들의 목록을 조회할 수 있어야 한다.

Change
---
1.  '사건-의뢰인' 테이블에서 해당 의뢰인 id에 대한 사건 id를 구한다.
2. '사건' 테이블에서 id가 앞서 구한 사건 id와 같은 사건 목록을 구한다.

위 단계의 쿼리문을 통해 의뢰인 id를 통해 해당 의뢰인에 등록된 사건들의 목록을 조회 할 수 있는 서비스를 추가했다.

Exception
---
해당 의뢰인이 DB에 없으면 ClientNotFoundException을 throw 한다.

Test
---
프론트 연동 후 테스트 완료