### PR TITLE
사원리스트 조회/필터링/검색/정렬/페이징 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
             .antMatchers("/tokens/**", "/test/**", "/hierarchy/**", "/role/**", "/court/**" ).permitAll()
             .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()
             .antMatchers(HttpMethod.POST, "/members/clients", "/members/employees").permitAll()
-            .antMatchers(HttpMethod.POST, "/promotions/clients").hasAnyRole("ADMIN", "EMPLOYEE")
+            .antMatchers(HttpMethod.POST, "/promotions/clients").hasRole("EMPLOYEE")
+            .antMatchers(HttpMethod.GET, "/members/employees").hasRole("EMPLOYEE")
             .antMatchers(HttpMethod.POST, "/promotions/employees").hasRole("ADMIN")
 
             .anyRequest().authenticated() //나머지 요청은 인증 필요

--- a/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
@@ -3,12 +3,15 @@ package com.avg.lawsuitmanagement.member.controller;
 import com.avg.lawsuitmanagement.member.controller.form.ClientSignUpForm;
 import com.avg.lawsuitmanagement.member.controller.form.EmployeeSignUpForm;
 import com.avg.lawsuitmanagement.member.controller.form.PrivateUpdateForm;
+import com.avg.lawsuitmanagement.member.controller.form.SearchEmployeeListForm;
+import com.avg.lawsuitmanagement.member.dto.GetMemberListDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.service.MemberService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,4 +48,15 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/employees")
+    public ResponseEntity<GetMemberListDto> searchEmployee(
+        @ModelAttribute SearchEmployeeListForm form) {
+        if(form.getHierarchyId() == null) {
+            form.setHierarchyId(0L);
+        }
+        if(form.getRoleId() == null) {
+            form.setRoleId(0L);
+        }
+        return ResponseEntity.ok(memberService.searchEmployeeList(form));
+    }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/controller/form/GetEmployeeListForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/controller/form/GetEmployeeListForm.java
@@ -1,0 +1,24 @@
+package com.avg.lawsuitmanagement.member.controller.form;
+
+import com.avg.lawsuitmanagement.member.type.MemberSortKey;
+import com.avg.lawsuitmanagement.member.type.MemberSortOrder;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class GetEmployeeListForm {
+
+    //검색 및 정렬
+    private String searchWord;
+    private long hierarchyId;
+    private long roleId;
+    private MemberSortKey memberSortKey;
+    private MemberSortOrder memberSortOrder;
+
+    //페이징
+    private int page;
+    private int rowsPerPage;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/controller/form/SearchEmployeeListForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/controller/form/SearchEmployeeListForm.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.member.controller.form;
 
 import com.avg.lawsuitmanagement.member.type.MemberSortKey;
 import com.avg.lawsuitmanagement.member.type.MemberSortOrder;
+import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,16 +10,18 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-public class GetEmployeeListForm {
+public class SearchEmployeeListForm {
 
     //검색 및 정렬
     private String searchWord;
-    private long hierarchyId;
-    private long roleId;
-    private MemberSortKey memberSortKey;
-    private MemberSortOrder memberSortOrder;
+    private Long hierarchyId;
+    private Long roleId;
+    private MemberSortKey sortKey;
+    private MemberSortOrder sortOrder;
 
     //페이징
-    private int page;
-    private int rowsPerPage;
+    @NotNull
+    private Integer page;
+    @NotNull
+    private Integer rowsPerPage;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/dto/GetMemberListDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/dto/GetMemberListDto.java
@@ -1,0 +1,16 @@
+package com.avg.lawsuitmanagement.member.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class GetMemberListDto {
+    int count;
+    List<MemberDtoNonPass> memberDtoNonPassList;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/dto/MemberDtoNonPass.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/dto/MemberDtoNonPass.java
@@ -19,5 +19,4 @@ public class MemberDtoNonPass {
     private long roleId; //역할 아이디
     private String createdAt; //생성일
     private String updatedAt; //수정일
-    private boolean isDeleted; //삭제여부
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/dto/MemberDtoNonPass.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/dto/MemberDtoNonPass.java
@@ -1,0 +1,23 @@
+package com.avg.lawsuitmanagement.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class MemberDtoNonPass {
+    private long id;
+    private String email; //이메일
+    private String name; //이름
+    private long hierarchyId; //직급 아이디
+    private String phone; //전화번호
+    private String address; //주소
+    private long roleId; //역할 아이디
+    private String createdAt; //생성일
+    private String updatedAt; //수정일
+    private boolean isDeleted; //삭제여부
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
@@ -1,7 +1,9 @@
 package com.avg.lawsuitmanagement.member.repository;
 
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import com.avg.lawsuitmanagement.member.dto.MemberDtoNonPass;
 import com.avg.lawsuitmanagement.member.repository.param.InsertMemberParam;
+import com.avg.lawsuitmanagement.member.repository.param.SearchEmployeeListParam;
 import com.avg.lawsuitmanagement.member.repository.param.UpdateMemberParam;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -13,4 +15,7 @@ public interface MemberMapperRepository {
     void insertMember(InsertMemberParam param);
     List<MemberDto> selectMemberListById(List<Long> memberExistList);
     void updateMember(UpdateMemberParam param);
+    List<MemberDtoNonPass> selectEmployeeListBySearchCondition(SearchEmployeeListParam param);
+    int selectEmployeeListBySearchConditionCount(SearchEmployeeListParam param);
+
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/repository/param/SearchEmployeeListParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/repository/param/SearchEmployeeListParam.java
@@ -1,0 +1,39 @@
+package com.avg.lawsuitmanagement.member.repository.param;
+
+import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
+import com.avg.lawsuitmanagement.member.controller.form.SearchEmployeeListForm;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class SearchEmployeeListParam {
+
+    //검색 및 정렬
+    private String searchWord;
+    private long hierarchyId;
+    private long roleId;
+    private String sortKey;
+    private String sortOrder;
+
+    //페이징
+    private int offset;
+    private int limit;
+
+    public static SearchEmployeeListParam of(SearchEmployeeListForm form, PagingDto pagingDto) {
+        return SearchEmployeeListParam.builder()
+            .searchWord(form.getSearchWord())
+            .hierarchyId(form.getHierarchyId())
+            .roleId(form.getRoleId())
+            .sortKey(
+                form.getSortKey() != null ? form.getSortKey().getQueryString() : null)
+            .sortOrder(
+                form.getSortOrder() != null ? form.getSortOrder().getQueryString()
+                    : null)
+            .offset(pagingDto.getOffset())
+            .limit(pagingDto.getLimit())
+            .build();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
@@ -7,15 +7,21 @@ import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
+import com.avg.lawsuitmanagement.common.util.PagingUtil;
 import com.avg.lawsuitmanagement.common.util.SecurityUtil;
 import com.avg.lawsuitmanagement.member.controller.form.ClientSignUpForm;
 import com.avg.lawsuitmanagement.member.controller.form.EmployeeSignUpForm;
 import com.avg.lawsuitmanagement.member.controller.form.PrivateUpdateForm;
+import com.avg.lawsuitmanagement.member.controller.form.SearchEmployeeListForm;
+import com.avg.lawsuitmanagement.member.dto.GetMemberListDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import com.avg.lawsuitmanagement.member.dto.MemberDtoNonPass;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
 import com.avg.lawsuitmanagement.member.repository.param.InsertMemberParam;
+import com.avg.lawsuitmanagement.member.repository.param.SearchEmployeeListParam;
 import com.avg.lawsuitmanagement.member.repository.param.UpdateMemberParam;
 import com.avg.lawsuitmanagement.promotion.service.PromotionService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -37,7 +43,7 @@ public class MemberService {
         return memberMapperRepository.selectMemberByEmail(email);
     }
 
-    public void updatePrivateInfo(PrivateUpdateForm form){
+    public void updatePrivateInfo(PrivateUpdateForm form) {
         MemberDto me = getLoginMemberInfo();
 
         memberMapperRepository.updateMember(UpdateMemberParam.of(form, me.getId()));
@@ -47,7 +53,7 @@ public class MemberService {
     public void clientSignUp(ClientSignUpForm form) {
         //1.가입키 검증
         ClientDto clientDto = promotionService.resolveClientPromotionKey(form.getPromotionKey());
-        if(clientDto.getMemberId() != 0) {
+        if (clientDto.getMemberId() != 0) {
             throw new CustomRuntimeException(CLIENT_ALREADY_REGISTERED);
         }
         //2. 프로모션 테이블 - 해당 키 비활성화
@@ -58,8 +64,8 @@ public class MemberService {
 
         //4. 의뢰인 테이블 - 회원 id 갱신
         clientMapperRepository.updateClientMemberId(UpdateClientMemberIdParam.builder()
-                .clientId(clientDto.getId())
-                .memberId(memberId)
+            .clientId(clientDto.getId())
+            .memberId(memberId)
             .build());
     }
 
@@ -73,10 +79,26 @@ public class MemberService {
         insertMember(InsertMemberParam.of(form, passwordEncoder));
     }
 
+    @Transactional
+    public GetMemberListDto searchEmployeeList(SearchEmployeeListForm form) {
+
+        SearchEmployeeListParam param = SearchEmployeeListParam.of(form,
+            PagingUtil.calculatePaging(form.getPage(), form.getRowsPerPage()));
+
+        List<MemberDtoNonPass> list =
+            memberMapperRepository.selectEmployeeListBySearchCondition(param);
+        int count = memberMapperRepository.selectEmployeeListBySearchConditionCount(param);
+
+        return GetMemberListDto.builder()
+            .count(count)
+            .memberDtoNonPassList(list)
+            .build();
+    }
+
     private long insertMember(InsertMemberParam param) {
         //이메일 중복체크
         MemberDto member = memberMapperRepository.selectMemberByEmail(param.getEmail());
-        if(member != null) {
+        if (member != null) {
             throw new CustomRuntimeException(MEMBER_EMAIL_ALREADY_EXIST);
         }
         memberMapperRepository.insertMember(param);

--- a/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortKey.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortKey.java
@@ -1,0 +1,17 @@
+package com.avg.lawsuitmanagement.member.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberSortKey {
+
+    CREATED_AT("가입일", "created_at"),
+    HIERARCHY("직급", "hierarchy"),
+    ROLE("권한", "role"),
+    EMAIL("이메일", "email");
+
+    private final String nameKr;
+    private final String queryString;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortKey.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortKey.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum MemberSortKey {
 
     CREATED_AT("가입일", "created_at"),
-    HIERARCHY("직급", "hierarchy"),
-    ROLE("권한", "role"),
+    HIERARCHY("직급", "hierarchy_id"),
+    ROLE("권한", "role_id"),
     EMAIL("이메일", "email");
 
     private final String nameKr;

--- a/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortOrder.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortOrder.java
@@ -1,0 +1,16 @@
+package com.avg.lawsuitmanagement.member.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberSortOrder {
+
+    ASC("오름차순", "asc"),
+    DESC("내림차순", "desc");
+
+
+    private final String nameKr;
+    private final String queryString;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/type/StringToMemberSortKey.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/type/StringToMemberSortKey.java
@@ -1,0 +1,21 @@
+package com.avg.lawsuitmanagement.member.type;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+
+/***
+ * form에서 enum 값을 받아 올 때, 클라이언트에서 소문자 값이 와도 적절한 enum으로 컨버팅 하기 위한 컨버터
+ */
+@Component
+public class StringToMemberSortKey implements Converter<String, MemberSortKey> {
+
+    @Override
+    public MemberSortKey convert(String input) {
+        String upperInput = input.toUpperCase();
+        if(upperInput.equals("CREATEDAT")) {
+            return MemberSortKey.CREATED_AT;
+        }
+        return MemberSortKey.valueOf(upperInput);
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/type/StringToMemberSortOrder.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/type/StringToMemberSortOrder.java
@@ -1,0 +1,16 @@
+package com.avg.lawsuitmanagement.member.type;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+
+/***
+ * form에서 enum 값을 받아 올 때, 클라이언트에서 소문자 값이 와도 적절한 enum으로 컨버팅 하기 위한 컨버터
+ */
+@Component
+public class StringToMemberSortOrder implements Converter<String, MemberSortOrder> {
+    @Override
+    public MemberSortOrder convert(String input) {
+        return MemberSortOrder.valueOf(input.toUpperCase());
+    }
+}

--- a/src/main/resources/mybatis/mapper/Member.xml
+++ b/src/main/resources/mybatis/mapper/Member.xml
@@ -40,4 +40,75 @@
         where id = #{id};
     </update>
 
+    <select id="selectEmployeeListBySearchCondition"
+      parameterType="searchEmployeeListParam"
+      resultType="MemberDtoNonPass">
+        select
+        id, email, name, hierarchy_id, phone, address, role_id, created_at, updated_at
+        from
+        member
+        <where>
+            <if test="searchWord != null and searchWord != ''">
+                and (name like concat('%', #{searchWord}, '%')
+                or email like concat('%', #{searchWord}, '%')
+                or phone like concat('%', #{searchWord}, '%'))
+            </if>
+
+            <if test="hierarchyId != 0">
+                and hierarchy_id = #{hierarchyId}
+            </if>
+
+            <if test="roleId != 0">
+                and role_id = #{roleId}
+            </if>
+            <if test="roleId == 0">
+                and role_id != 1
+            </if>
+            and is_deleted = false
+        </where>
+        <choose>
+            <when
+              test="sortKey != null and sortKey != '' and sortOrder != null and sortOrder.toUpperCase() == 'ASC'">
+                order by ${sortKey} asc
+            </when>
+            <when
+              test="sortKey != null and sortKey != '' and sortOrder != null and sortOrder.toUpperCase() == 'DESC'">
+                order by ${sortKey} desc
+            </when>
+            <otherwise>
+                order by created_at desc
+            </otherwise>
+        </choose>
+
+        limit #{offset}, #{limit}
+    </select>
+
+    <select id="selectEmployeeListBySearchConditionCount" parameterType="searchEmployeeListParam"
+      resultType="int">
+        select
+        count(*)
+        from
+        member
+        <where>
+            <if test="searchWord != null and searchWord != ''">
+                and (name like concat('%', #{searchWord}, '%')
+                or email like concat('%', #{searchWord}, '%')
+                or phone like concat('%', #{searchWord}, '%'))
+            </if>
+
+            <if test="hierarchyId != 0">
+                and hierarchy_id = #{hierarchyId}
+            </if>
+
+            <if test="roleId != 0">
+                and role_id = #{roleId}
+            </if>
+            <if test="roleId == 0">
+                and role_id != 1
+            </if>
+
+            and is_deleted = false
+        </where>
+    </select>
+
 </mapper>


### PR DESCRIPTION
Change
---
사원목록 조회를 구현하였다.
구현된 기능은 다음과 같다.

> 직급(전체, 사원, 대리...사무장), 권한(전체, 일반직원, 관리자) 로 필터링 하는 기능
> 정렬기준(가입일, 직급, 권한, 이메일), 정렬순서(내림차순, 오름차순) 으로 정렬하는 기능
> 이름, 전화번호, email로 검색하는 기능
> 페이징 기능(페이지당 글 수 설정 가능)

Test
---
프론트 연동 후 테스트 완료