### PR TITLE
Client Controller URL 수정 및 사건목록 검색, 페이징 기능 추가

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/form/GetClientLawsuitForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/form/GetClientLawsuitForm.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 public class GetClientLawsuitForm {
     private Integer curPage;
     private Integer rowsPerPage;
+    private String searchWord;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/controller/form/GetClientLawsuitForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/controller/form/GetClientLawsuitForm.java
@@ -6,6 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class GetClientLawsuitForm {
-    private int curPage;
-    private int itemsPerPage;
+    private Integer curPage;
+    private Integer rowsPerPage;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/dto/ClientLawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/dto/ClientLawsuitDto.java
@@ -1,6 +1,5 @@
 package com.avg.lawsuitmanagement.client.dto;
 
-import com.avg.lawsuitmanagement.common.util.dto.PageRangeDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import java.util.List;
 import lombok.Builder;
@@ -12,12 +11,5 @@ import lombok.Setter;
 @Builder
 public class ClientLawsuitDto {
     private List<LawsuitDto> lawsuitList;
-    private PageRangeDto pageRange;
-
-     public static ClientLawsuitDto of (List<LawsuitDto> lawsuitList, PageRangeDto pageRange) {
-         return ClientLawsuitDto.builder()
-            .lawsuitList(lawsuitList)
-            .pageRange(pageRange)
-            .build();
-    }
+    private int count;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.client.repository;
 
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
+import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
 import java.util.List;
@@ -17,6 +18,6 @@ public interface ClientMapperRepository {
     void updateClientInfo(UpdateClientInfoParam param);
     void deleteClientInfo(long clientId);
     List<ClientDto> selectClientList();
-    int getLawsuitCountByClientId(long clientId);
+    int selectClientLawsuitCountBySearchWord(SelectClientLawsuitListParam param);
     List<ClientDto> selectClientListById(List<Long> clientIdList);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -2,11 +2,8 @@ package com.avg.lawsuitmanagement.client.repository;
 
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
-import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
-import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
-import java.util.HashMap;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -20,6 +17,6 @@ public interface ClientMapperRepository {
     void updateClientInfo(UpdateClientInfoParam param);
     void deleteClientInfo(long clientId);
     List<ClientDto> selectClientList();
-    long getLawsuitCountByClientId(long clientId);
+    int getLawsuitCountByClientId(long clientId);
     List<ClientDto> selectClientListById(List<Long> clientIdList);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/param/SelectClientLawsuitListParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/param/SelectClientLawsuitListParam.java
@@ -12,13 +12,15 @@ public class SelectClientLawsuitListParam {
     private long clientId;
     private int offset;
     private int limit;
+    private String searchWord;
 
 
-    public static SelectClientLawsuitListParam of(long clientId, PagingDto pagingDto) {
+    public static SelectClientLawsuitListParam of(long clientId, PagingDto pagingDto, String searchWord) {
         return SelectClientLawsuitListParam.builder()
             .clientId(clientId)
             .offset(pagingDto.getOffset())
             .limit(pagingDto.getLimit())
+            .searchWord(searchWord)
             .build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PagingDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/util/dto/PagingDto.java
@@ -3,8 +3,6 @@ package com.avg.lawsuitmanagement.common.util.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Getter

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -48,12 +48,6 @@ public class LawsuitController {
         return ResponseEntity.ok(lawsuitService.selectLawsuitList());
     }
 
-    // 의뢰인에 대한 사건 조회
-    @GetMapping("/{clientId}")
-    public ResponseEntity<List<LawsuitDto>> selectLawsuitByClientId(@PathVariable("clientId") Long clientId) {
-        return ResponseEntity.ok(lawsuitService.selectLawsuitByClientId(clientId));
-    }
-
     // 사건 수정
     @PutMapping("/{lawsuitId}")
     public ResponseEntity<Void> updateLawsuitInfo(@PathVariable("lawsuitId") Long lawsuitId, @RequestBody @Valid UpdateLawsuitInfoForm form) {

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -30,13 +30,14 @@ public class LawsuitController {
     private final ClientService clientService;
 
     // 의뢰인 사건 리스트, 페이징 정보
-    @GetMapping("/clients/{clientId}")  // url 수정 필요
+    @GetMapping("/clients/{clientId}")
     public ResponseEntity<ClientLawsuitDto> selectClientLawsuitList(
         @PathVariable("clientId") Long clientId,
         @ModelAttribute GetClientLawsuitForm form) {
 
         return ResponseEntity.ok(lawsuitService.selectClientLawsuitList(clientId, form));
     }
+
     // 사건 등록
     @PostMapping()
     public ResponseEntity<Void> insertLawsuit(@RequestBody @Valid InsertLawsuitForm form) {

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -14,7 +14,6 @@ import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitList
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.util.PagingUtil;
 import com.avg.lawsuitmanagement.common.util.SecurityUtil;
-import com.avg.lawsuitmanagement.common.util.dto.PageRangeDto;
 import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
@@ -48,18 +47,22 @@ public class LawsuitService {
             throw new CustomRuntimeException(CLIENT_NOT_FOUND);
         }
 
-        long total = clientMapperRepository.getLawsuitCountByClientId(clientId);
-        System.out.println("total = " + total);
+        int count = clientMapperRepository.getLawsuitCountByClientId(clientId);
 
-        PagingDto pagingDto = PagingUtil.calculatePaging(form.getCurPage(), form.getItemsPerPage());
+        PagingDto pagingDto = PagingUtil.calculatePaging(form.getCurPage(), form.getRowsPerPage());
         SelectClientLawsuitListParam param = SelectClientLawsuitListParam.of(clientId, pagingDto);
+
+        if (form.getCurPage() == null || form.getRowsPerPage() == null) {
+            param.setOffset(0);
+            param.setLimit(0);
+        }
         // 한 페이지에 나타나는 사건 리스트 목록
         List<LawsuitDto> lawsuitList = lawsuitMapperRepository.selectClientLawsuitList(param);
 
-        // startPage, endPage 저장
-        PageRangeDto pageRangeDto = PagingUtil.calculatePageRange(form.getCurPage(), total);
-
-        return ClientLawsuitDto.of(lawsuitList, pageRangeDto);
+        return ClientLawsuitDto.builder()
+                .lawsuitList(lawsuitList)
+                .count(count)
+                .build();
     }
 
     @Transactional
@@ -149,16 +152,5 @@ public class LawsuitService {
         lawsuitMapperRepository.deleteLawsuitInfo(lawsuitId);
         lawsuitMapperRepository.deleteLawsuitClientMap(lawsuitId);
         lawsuitMapperRepository.deleteLawsuitMemberMap(lawsuitId);
-    }
-
-    // 해당 의뢰인에 대한 사건 조회
-    public List<LawsuitDto> selectLawsuitByClientId(long clientId) {
-        ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
-
-        if (clientDto == null) {
-            throw new CustomRuntimeException(CLIENT_NOT_FOUND);
-        }
-
-        return lawsuitMapperRepository.selectLawsuitByClientId(clientId);
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -47,10 +47,9 @@ public class LawsuitService {
             throw new CustomRuntimeException(CLIENT_NOT_FOUND);
         }
 
-        int count = clientMapperRepository.getLawsuitCountByClientId(clientId);
 
         PagingDto pagingDto = PagingUtil.calculatePaging(form.getCurPage(), form.getRowsPerPage());
-        SelectClientLawsuitListParam param = SelectClientLawsuitListParam.of(clientId, pagingDto);
+        SelectClientLawsuitListParam param = SelectClientLawsuitListParam.of(clientId, pagingDto, form.getSearchWord());
 
         if (form.getCurPage() == null || form.getRowsPerPage() == null) {
             param.setOffset(0);
@@ -58,6 +57,7 @@ public class LawsuitService {
         }
         // 한 페이지에 나타나는 사건 리스트 목록
         List<LawsuitDto> lawsuitList = lawsuitMapperRepository.selectClientLawsuitList(param);
+        int count = clientMapperRepository.selectClientLawsuitCountBySearchWord(param);
 
         return ClientLawsuitDto.builder()
                 .lawsuitList(lawsuitList)

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -46,7 +46,7 @@
         where is_deleted = false;
     </select>
 
-    <select id="getLawsuitCountByClientId" parameterType="java.lang.Long" resultType="java.lang.Long">
+    <select id="getLawsuitCountByClientId" parameterType="java.lang.Long">
         select count(*)
         from lawsuit l
                  join lawsuit_client_map map on l.id = map.lawsuit_id

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -46,12 +46,18 @@
         where is_deleted = false;
     </select>
 
-    <select id="getLawsuitCountByClientId" parameterType="java.lang.Long">
+    <select id="selectClientLawsuitCountBySearchWord" parameterType="SelectClientLawsuitListParam">
         select count(*)
         from lawsuit l
-                 join lawsuit_client_map map on l.id = map.lawsuit_id
+        join lawsuit_client_map map on l.id = map.lawsuit_id
         where map.client_id = #{clientId}
-          and l.is_deleted = false
+        and l.is_deleted = false
+        <if test="searchWord != ''">
+            and (
+            name like concat('%', #{searchWord}, '%') or
+            lawsuit_num like concat('%', #{searchWord}, '%')
+            )
+        </if>
     </select>
 
     <select id="selectClientListById" parameterType="java.util.List">

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -11,6 +11,12 @@
                  join lawsuit_client_map map on l.id = map.lawsuit_id
         where map.client_id = #{clientId}
           and l.is_deleted = false
+        <if test="searchWord != ''">
+            and (
+                name like concat('%', #{searchWord}, '%') or
+                lawsuit_num like concat('%', #{searchWord}, '%')
+            )
+        </if>
         order by l.created_at desc
         <if test="limit != 0 or offset != 0">
             limit #{limit} offset #{offset}

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -12,7 +12,9 @@
         where map.client_id = #{clientId}
           and l.is_deleted = false
         order by l.created_at desc
-        limit #{limit} offset #{offset}
+        <if test="limit != 0 or offset != 0">
+            limit #{limit} offset #{offset}
+        </if>
     </select>
 
     <select id="selectLawsuitById" parameterType="java.lang.Long">


### PR DESCRIPTION
Background
---
기존 컨트롤러에서는 

1. 의뢰인별 사건 목록과 페이징 정보를 반환하는 메서드 ( /lawsuits/clients/{clientId} )
2. 단순 의뢰인별 사건 목록을 반환하는 메서드 ( /lawsuits/{clientId} )

두 가지를 생성했었다.

하지만 API 명세서상 의뢰인에 대한 사건 상세 목록을 조회하는 URL은 /lawsuits/clients/{clientId} 경로이기 때문에 수정해야 했다.

사건-사건목록 탭에서 사건 검색 기능 추가 (페이징 기능 포함)

Change
---
단순 의뢰인별 사건 목록을 반환하는 메서드를 없애고, 의뢰인별 사건 목록과 페이징 정보를 반환하는 메서드 하나로 합쳤다.
쿼리에서 조건에 따라 사건 목록만 반환할지 페이징 정보도 함께 반환할지 결정하도록 변경하였다.

페이지를 변경할 때마다 request를 통해 해당 페이지에 나타낼 사건 목록을 요청하도록 했다.
또한 검색시 해당 내용이 포함된 사건명과 사건번호를 검색할 수 있도록 하였다.

Test
---
front 연동을 통한 테스트 완료