### PR TITLE
사건 공통 헤더 관련 API 추가

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -4,6 +4,7 @@ import com.avg.lawsuitmanagement.client.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.client.dto.ClientLawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import java.util.List;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/lawsuits")
 public class LawsuitController {
+
     private final LawsuitService lawsuitService;
 
     // 의뢰인 사건 리스트, 페이징 정보
@@ -50,7 +52,8 @@ public class LawsuitController {
 
     // 사건 수정
     @PutMapping("/{lawsuitId}")
-    public ResponseEntity<Void> updateLawsuitInfo(@PathVariable("lawsuitId") Long lawsuitId, @RequestBody @Valid UpdateLawsuitInfoForm form) {
+    public ResponseEntity<Void> updateLawsuitInfo(@PathVariable("lawsuitId") Long lawsuitId,
+        @RequestBody @Valid UpdateLawsuitInfoForm form) {
         lawsuitService.updateLawsuitInfo(lawsuitId, form);
         return ResponseEntity.ok().build();
     }
@@ -60,6 +63,12 @@ public class LawsuitController {
     public ResponseEntity<Void> deleteLawsuitInfo(@PathVariable("lawsuitId") Long lawsuitId) {
         lawsuitService.deleteLawsuitInfo(lawsuitId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{lawsuitId}/basic")
+    public ResponseEntity<?> getBasicLawsuitInfo(@PathVariable Long lawsuitId) {
+        LawsuitBasicDto result = lawsuitService.getBasicLawsuitInfo(lawsuitId);
+        return ResponseEntity.ok(result);
     }
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/BasicLawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/BasicLawsuitDto.java
@@ -1,0 +1,27 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class BasicLawsuitDto {
+
+    private Long lawsuitId;
+    private String lawsuitNum;
+    private String lawsuitName;
+    private String lawsuitType;
+    private Long lawsuitCommissionFee;
+    private Long lawsuitContingentFee;
+    private String lawsuitStatus;
+    private String courtName;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/BasicUserDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/BasicUserDto.java
@@ -1,0 +1,21 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class BasicUserDto {
+
+    private Long id;
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitBasicDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitBasicDto.java
@@ -1,0 +1,23 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LawsuitBasicDto {
+
+    private BasicLawsuitDto lawsuit;
+    private List<BasicUserDto> employees;
+    private List<BasicUserDto> clients;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitBasicRawDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitBasicRawDto.java
@@ -1,0 +1,33 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LawsuitBasicRawDto {
+
+    private Long lawsuitId;
+    private String lawsuitNum;
+    private String lawsuitName;
+    private String lawsuitType;
+    private Long lawsuitCommissionFee;
+    private Long lawsuitContingentFee;
+    private String lawsuitStatus;
+    private String courtName;
+    private Long employeeId;
+    private String employeeName;
+    private String employeeEmail;
+    private Long clientId;
+    private String clientName;
+    private String clientEmail;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.lawsuit.repository;
 
 import com.avg.lawsuitmanagement.client.dto.ClientLawsuitCountDto;
 import com.avg.lawsuitmanagement.client.repository.param.SelectClientLawsuitListParam;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicRawDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitClientMemberIdParam;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
@@ -11,20 +12,37 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface LawsuitMapperRepository {
+
     List<LawsuitDto> selectClientLawsuitList(SelectClientLawsuitListParam param);
+
     LawsuitDto selectLawsuitById(long lawsuitId);
+
     void insertLawsuit(InsertLawsuitParam param);
+
     Long getLastInsertedLawsuitId();
+
     void insertLawsuitClientMap(InsertLawsuitClientMemberIdParam param);
+
     void insertLawsuitMemberMap(InsertLawsuitClientMemberIdParam param);
+
     List<LawsuitDto> selectLawsuitList();
+
     void updateLawsuitInfo(UpdateLawsuitInfoParam param);
+
     List<Long> selectMemberByLawsuitId(long lawsuitId);
+
     void deleteLawsuitInfo(long lawsuitId);
+
     void deleteLawsuitClientMap(long lawsuitId);
+
     void deleteLawsuitMemberMap(long lawsuitId);
+
     void deleteLawsuitClientMapByClientId(long clientId);
+
     List<ClientLawsuitCountDto> selectLawsuitCountByClientId(long clientId);
+
     List<LawsuitDto> selectLawsuitByClientId(long clientId);
+
+    List<LawsuitBasicRawDto> selectBasicLawInfo(Long lawsuitId);
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -2,9 +2,9 @@ package com.avg.lawsuitmanagement.lawsuit.service;
 
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_NOT_FOUND;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.LAWSUIT_NOT_FOUND;
+import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.LAWSUIT_STATUS_NOT_FOUND;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.MEMBER_NOT_ASSIGNED_TO_LAWSUIT;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.MEMBER_NOT_FOUND;
-import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.LAWSUIT_STATUS_NOT_FOUND;
 
 import com.avg.lawsuitmanagement.client.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
@@ -17,6 +17,10 @@ import com.avg.lawsuitmanagement.common.util.SecurityUtil;
 import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.BasicLawsuitDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.BasicUserDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicRawDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitClientMemberIdParam;
@@ -25,7 +29,9 @@ import com.avg.lawsuitmanagement.lawsuit.repository.param.UpdateLawsuitInfoParam
 import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class LawsuitService {
+
     private final ClientMapperRepository clientMapperRepository;
     private final MemberMapperRepository memberMapperRepository;
     private final LawsuitMapperRepository lawsuitMapperRepository;
@@ -47,9 +54,9 @@ public class LawsuitService {
             throw new CustomRuntimeException(CLIENT_NOT_FOUND);
         }
 
-
         PagingDto pagingDto = PagingUtil.calculatePaging(form.getCurPage(), form.getRowsPerPage());
-        SelectClientLawsuitListParam param = SelectClientLawsuitListParam.of(clientId, pagingDto, form.getSearchWord());
+        SelectClientLawsuitListParam param = SelectClientLawsuitListParam.of(clientId, pagingDto,
+            form.getSearchWord());
 
         if (form.getCurPage() == null || form.getRowsPerPage() == null) {
             param.setOffset(0);
@@ -60,9 +67,9 @@ public class LawsuitService {
         int count = clientMapperRepository.selectClientLawsuitCountBySearchWord(param);
 
         return ClientLawsuitDto.builder()
-                .lawsuitList(lawsuitList)
-                .count(count)
-                .build();
+            .lawsuitList(lawsuitList)
+            .count(count)
+            .build();
     }
 
     @Transactional
@@ -86,7 +93,8 @@ public class LawsuitService {
                 throw new CustomRuntimeException(MEMBER_NOT_FOUND);
             }
         }
-        lawsuitMapperRepository.insertLawsuit(InsertLawsuitParam.of(form, LawsuitStatus.REGISTRATION));
+        lawsuitMapperRepository.insertLawsuit(
+            InsertLawsuitParam.of(form, LawsuitStatus.REGISTRATION));
 
         // 등록한 사건의 id값
         long lawsuitId = lawsuitMapperRepository.getLastInsertedLawsuitId();
@@ -110,7 +118,7 @@ public class LawsuitService {
 
     public void updateLawsuitInfo(long lawsuitId, UpdateLawsuitInfoForm form) {
         LawsuitDto lawsuitDto = lawsuitMapperRepository.selectLawsuitById(lawsuitId);
-        
+
         // lawsuitId에 해당하는 사건이 없다면
         if (lawsuitDto == null) {
             throw new CustomRuntimeException(LAWSUIT_NOT_FOUND);
@@ -128,7 +136,8 @@ public class LawsuitService {
             throw new CustomRuntimeException(LAWSUIT_STATUS_NOT_FOUND);
         }
 
-        lawsuitMapperRepository.updateLawsuitInfo(UpdateLawsuitInfoParam.of(lawsuitId, form, lawsuitStatus));
+        lawsuitMapperRepository.updateLawsuitInfo(
+            UpdateLawsuitInfoParam.of(lawsuitId, form, lawsuitStatus));
     }
 
     @Transactional
@@ -153,4 +162,54 @@ public class LawsuitService {
         lawsuitMapperRepository.deleteLawsuitClientMap(lawsuitId);
         lawsuitMapperRepository.deleteLawsuitMemberMap(lawsuitId);
     }
+
+
+    public LawsuitBasicDto getBasicLawsuitInfo(Long lawsuitId) {
+        List<LawsuitBasicRawDto> raws = lawsuitMapperRepository.selectBasicLawInfo(
+            lawsuitId);
+
+        if (raws.isEmpty()) {
+            throw new RuntimeException("");
+        }
+
+        LawsuitBasicRawDto lawsuitItem = raws.get(0);
+        BasicLawsuitDto lawsuit = BasicLawsuitDto.builder()
+            .lawsuitId(lawsuitItem.getLawsuitId())
+            .lawsuitNum(lawsuitItem.getLawsuitNum())
+            .lawsuitName(lawsuitItem.getLawsuitName())
+            .lawsuitType(lawsuitItem.getLawsuitType())
+            .lawsuitCommissionFee(lawsuitItem.getLawsuitCommissionFee())
+            .lawsuitContingentFee(lawsuitItem.getLawsuitContingentFee())
+            .lawsuitStatus(lawsuitItem.getLawsuitStatus())
+            .build();
+
+        Map<Long, BasicUserDto> clientMap = new HashMap<>();
+        Map<Long, BasicUserDto> employeeMap = new HashMap<>();
+        for (LawsuitBasicRawDto raw : raws) {
+            Long clientId = raw.getClientId();
+            BasicUserDto client = BasicUserDto.builder()
+                .id(clientId)
+                .name(raw.getClientName())
+                .email(raw.getClientEmail())
+                .build();
+            clientMap.put(clientId, client);
+
+            Long employeeId = raw.getEmployeeId();
+            BasicUserDto employee = BasicUserDto.builder()
+                .id(employeeId)
+                .name(raw.getEmployeeName())
+                .email(raw.getEmployeeEmail())
+                .build();
+            employeeMap.put(employeeId, employee);
+        }
+
+        LawsuitBasicDto result = LawsuitBasicDto.builder()
+            .lawsuit(lawsuit)
+            .employees(employeeMap.values().stream().toList())
+            .clients(clientMap.values().stream().toList())
+            .build();
+
+        return result;
+    }
+
 }

--- a/src/main/java/com/avg/lawsuitmanagement/reception/controller/ReceptionController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/reception/controller/ReceptionController.java
@@ -13,6 +13,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -96,7 +97,7 @@ public class ReceptionController {
         return ResponseEntity.ok(result);
     }
 
-    @PutMapping("/delete/{id}")
+    @PatchMapping("/delete/{id}")
     public ResponseEntity<?> remove(
         @PathVariable
         Long id

--- a/src/main/java/com/avg/lawsuitmanagement/reception/controller/form/ReceptionCreateForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/reception/controller/form/ReceptionCreateForm.java
@@ -29,9 +29,10 @@ public class ReceptionCreateForm {
     private LocalDate receivedAt;
     private LocalDate deadline;
 
-    public ReceptionInsertParam toParam() {
+    public ReceptionInsertParam toParam(Long memberId) {
         return ReceptionInsertParam.builder()
             .lawsuitId(lawsuitId)
+            .memberId(memberId)
             .status(status.equals("complete"))
             .category(category)
             .contents(contents)

--- a/src/main/java/com/avg/lawsuitmanagement/reception/dto/ReceptionDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/reception/dto/ReceptionDto.java
@@ -19,6 +19,7 @@ public class ReceptionDto {
 
     private Long id;
     private Long lawsuitId;
+    private Long memberId;
     private Boolean status;
     private String category;
     private String contents;

--- a/src/main/java/com/avg/lawsuitmanagement/reception/repository/param/ReceptionInsertParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/reception/repository/param/ReceptionInsertParam.java
@@ -18,6 +18,7 @@ public class ReceptionInsertParam {
 
     private Long id;
     private Long lawsuitId;
+    private Long memberId;
     private Boolean status;
     private String category;
     private String contents;

--- a/src/main/java/com/avg/lawsuitmanagement/reception/service/ReceptionService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/reception/service/ReceptionService.java
@@ -1,5 +1,7 @@
 package com.avg.lawsuitmanagement.reception.service;
 
+import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import com.avg.lawsuitmanagement.member.service.MemberService;
 import com.avg.lawsuitmanagement.reception.controller.form.ReceptionCreateForm;
 import com.avg.lawsuitmanagement.reception.controller.form.ReceptionEditForm;
 import com.avg.lawsuitmanagement.reception.controller.form.ReceptionSearchForm;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class ReceptionService {
 
     private final ReceptionMapperRepository receptionRepository;
+    private final MemberService memberService;
 
     public List<ReceptionDto> search(ReceptionSearchForm form) {
         ReceptionSelectParam param = form.toParam();
@@ -31,7 +34,8 @@ public class ReceptionService {
     }
 
     public ReceptionDto create(ReceptionCreateForm form) {
-        ReceptionInsertParam param = form.toParam();
+        MemberDto member = memberService.getLoginMemberInfo();
+        ReceptionInsertParam param = form.toParam(member.getId());
         receptionRepository.insert(param);
         Long id = param.getId();
         ReceptionDto result = receptionRepository.selectById(id);

--- a/src/main/java/com/avg/lawsuitmanagement/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/schedule/controller/ScheduleController.java
@@ -41,7 +41,7 @@ public class ScheduleController {
         return ResponseEntity.ok(result);
     }
 
-    @GetMapping("/info/{id}")
+    @GetMapping("/{id}/info")
     public ResponseEntity<?> searchInfo(@PathVariable(name = "id") Long receptionId) {
         ScheduleInfoDto result = scheduleService.searchInfo(receptionId);
         return ResponseEntity.ok(result);

--- a/src/main/java/com/avg/lawsuitmanagement/schedule/controller/form/ScheduleSearchForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/schedule/controller/form/ScheduleSearchForm.java
@@ -20,8 +20,9 @@ public class ScheduleSearchForm {
     private LocalDate startDeadline;
     private LocalDate endDeadline;
 
-    public ScheduleSelectParam toParam() {
+    public ScheduleSelectParam toParam(Long memberId) {
         return ScheduleSelectParam.builder()
+            .memberId(memberId)
             .startDeadline(startDeadline)
             .endDeadline(endDeadline)
             .build();

--- a/src/main/java/com/avg/lawsuitmanagement/schedule/repository/param/ScheduleSelectParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/schedule/repository/param/ScheduleSelectParam.java
@@ -16,6 +16,7 @@ import lombok.ToString;
 @ToString
 public class ScheduleSelectParam {
 
+    private Long memberId;
     private LocalDate startDeadline;
     private LocalDate endDeadline;
 

--- a/src/main/java/com/avg/lawsuitmanagement/schedule/service/ScheduleService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/schedule/service/ScheduleService.java
@@ -1,5 +1,7 @@
 package com.avg.lawsuitmanagement.schedule.service;
 
+import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import com.avg.lawsuitmanagement.member.service.MemberService;
 import com.avg.lawsuitmanagement.schedule.controller.form.ScheduleSearchForm;
 import com.avg.lawsuitmanagement.schedule.dto.ScheduleClientInfoDto;
 import com.avg.lawsuitmanagement.schedule.dto.ScheduleDto;
@@ -25,9 +27,11 @@ import org.springframework.stereotype.Service;
 public class ScheduleService {
 
     private final ScheduleMapperRepository scheduleRepository;
+    private final MemberService memberService;
 
     public List<ScheduleDto> search(ScheduleSearchForm form) {
-        ScheduleSelectParam param = form.toParam();
+        MemberDto member = memberService.getLoginMemberInfo();
+        ScheduleSelectParam param = form.toParam(member.getId());
 
         List<ScheduleRawDto> rawDto = scheduleRepository.select(param);
 

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -5,16 +5,17 @@
 
 <mapper namespace="com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository">
 
-    <select id="selectClientLawsuitList" parameterType="SelectClientLawsuitListParam" resultType="LawsuitDto">
+    <select id="selectClientLawsuitList" parameterType="SelectClientLawsuitListParam"
+      resultType="LawsuitDto">
         select l.*
         from lawsuit l
-                 join lawsuit_client_map map on l.id = map.lawsuit_id
+        join lawsuit_client_map map on l.id = map.lawsuit_id
         where map.client_id = #{clientId}
-          and l.is_deleted = false
+        and l.is_deleted = false
         <if test="searchWord != ''">
             and (
-                name like concat('%', #{searchWord}, '%') or
-                lawsuit_num like concat('%', #{searchWord}, '%')
+            name like concat('%', #{searchWord}, '%') or
+            lawsuit_num like concat('%', #{searchWord}, '%')
             )
         </if>
         order by l.created_at desc
@@ -26,12 +27,15 @@
     <select id="selectLawsuitById" parameterType="java.lang.Long">
         select *
         from lawsuit
-        where id = #{lawsuitId} and is_deleted = false;
+        where id = #{lawsuitId}
+          and is_deleted = false;
     </select>
 
     <insert id="insertLawsuit" parameterType="InsertLawsuitParam">
-        insert into lawsuit (lawsuit_type, name, court_id, commission_fee, contingent_fee, lawsuit_status, lawsuit_num, result)
-        values (#{lawsuitType}, #{name}, #{courtId}, #{commissionFee}, #{contingentFee}, #{lawsuitStatus}, #{lawsuitNum}, null);
+        insert into lawsuit (lawsuit_type, name, court_id, commission_fee, contingent_fee,
+                             lawsuit_status, lawsuit_num, result)
+        values (#{lawsuitType}, #{name}, #{courtId}, #{commissionFee}, #{contingentFee},
+                #{lawsuitStatus}, #{lawsuitNum}, null);
     </insert>
 
     <!-- 추가한 데이터의 id 값을 가져옴 -->
@@ -65,10 +69,15 @@
 
     <update id="updateLawsuitInfo">
         update lawsuit
-        set lawsuit_type = #{lawsuit_type}, name = #{name}, court_id = #{court_id},
-            commission_fee = #{commission_fee}, contingent_fee = #{contingent_fee},
-            lawsuit_status = #{lawsuit_status}, lawsuit_num = #{lawsuit_num},
-            result = #{result}, judgement_date = #{judgement_date}
+        set lawsuit_type   = #{lawsuit_type},
+            name           = #{name},
+            court_id       = #{court_id},
+            commission_fee = #{commission_fee},
+            contingent_fee = #{contingent_fee},
+            lawsuit_status = #{lawsuit_status},
+            lawsuit_num    = #{lawsuit_num},
+            result         = #{result},
+            judgement_date = #{judgement_date}
         where id = #{lawsuitId};
     </update>
 
@@ -101,7 +110,8 @@
         select lcm1.lawsuit_id, count(*)
         from lawsuit_client_map lcm1
                  join lawsuit_client_map lcm2 on lcm1.lawsuit_id = lcm2.lawsuit_id
-        where lcm1.is_deleted = false and lcm1.client_id = #{clientId}
+        where lcm1.is_deleted = false
+          and lcm1.client_id = #{clientId}
         group by lcm1.lawsuit_id;
     </select>
 
@@ -116,10 +126,36 @@
     <select id="selectLawsuitByClientId" parameterType="java.lang.Long">
         select *
         from lawsuit
-        where id in (
-            select lawsuit_id
-            from lawsuit_client_map
-            where lawsuit.is_deleted = false and client_id = #{clientId}
-            );
+        where id in (select lawsuit_id
+                     from lawsuit_client_map
+                     where lawsuit.is_deleted = false
+                       and client_id = #{clientId});
+    </select>
+
+    <select id="selectBasicLawInfo"
+      parameterType="java.lang.Long"
+      resultType="com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicRawDto">
+        SELECT l.id             `lawsuit_id`,
+               l.lawsuit_num    `lawsuit_num`,
+               l.name           `lawsuit_name`,
+               l.lawsuit_type   `lawsuit_type`,
+               l.lawsuit_status `lawsuit_status`,
+               l.commission_fee `lawsuit_commission_fee`,
+               l.contingent_fee `lawsuit_contingent_fee`,
+               co.name_kr       `court_name`,
+               m.id             `employee_id`,
+               m.name           `employee_name`,
+               m.email          `employee_email`,
+               c.id             `client_id`,
+               c.name           `client_name`,
+               c.email          `client_email`
+        FROM lawsuit l
+                 LEFT JOIN court co ON l.court_id = co.id
+                 LEFT JOIN lawsuit_member_map lm ON lm.lawsuit_id = l.id
+                 LEFT JOIN member m ON lm.member_id = m.id
+                 LEFT JOIN lawsuit_client_map lc ON lc.lawsuit_id = l.id
+                 LEFT JOIN client c ON lc.client_id = c.id
+        WHERE l.is_deleted = 0
+          AND l.id = #{lawsuitId};
     </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/Reception.xml
+++ b/src/main/resources/mybatis/mapper/Reception.xml
@@ -9,6 +9,7 @@
       resultType="com.avg.lawsuitmanagement.reception.dto.ReceptionDto">
         SELECT id,
         lawsuit_id,
+        member_id,
         status,
         category,
         contents,
@@ -75,6 +76,7 @@
       resultType="com.avg.lawsuitmanagement.reception.dto.ReceptionDto">
         SELECT id,
                lawsuit_id,
+               member_id,
                status,
                category,
                contents,
@@ -92,8 +94,10 @@
       useGeneratedKeys="true"
       keyProperty="id"
     >
-        INSERT INTO reception (lawsuit_id, status, category, contents, received_at, deadline)
-        VALUES (#{lawsuitId}, #{status}, #{category}, #{contents}, #{receivedAt}, #{deadline})
+        INSERT INTO reception (lawsuit_id, member_id, status, category, contents, received_at,
+                               deadline)
+        VALUES (#{lawsuitId}, #{memberId}, #{status}, #{category}, #{contents}, #{receivedAt},
+                #{deadline})
     </insert>
     <update id="update"
       parameterType="com.avg.lawsuitmanagement.reception.repository.param.ReceptionUpdateParam">

--- a/src/main/resources/mybatis/mapper/Schedule.xml
+++ b/src/main/resources/mybatis/mapper/Schedule.xml
@@ -18,6 +18,7 @@
                  JOIN lawsuit_member_map map ON l.id = map.lawsuit_id
                  JOIN member m ON m.id = map.member_id
         WHERE r.is_deleted = false
+          AND r.member_id = #{memberId}
           AND deadline >= #{startDeadline}
           AND #{endDeadline} >= deadline
     </select>


### PR DESCRIPTION
## Background

- 사건 레이아웃의 공통 헤더에서 쓸 수 있는 API가 없기 때문에 추가

## Change

- lawsuit 도메인에 GET /{lawsuitId}/basic 엔드 포인트 및 기능 추가

## Test

프론트엔드 애플리케이션과 연동 테스트