### PR TITLE
시큐리티 - 인가 예외처리

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.common.config;
 
 
+import com.avg.lawsuitmanagement.common.custom.CustomAccessDeniedHandler;
 import com.avg.lawsuitmanagement.common.custom.CustomAuthenticationEntryPoint;
 import com.avg.lawsuitmanagement.token.provider.TokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -59,6 +61,8 @@ public class SecurityConfig {
             .and()
             .exceptionHandling()
             .authenticationEntryPoint(customAuthenticationEntryPoint)
+            //인가 예외처리
+            .accessDeniedHandler(customAccessDeniedHandler)
 
             .and()
             .addFilterBefore(new JwtFilter(tokenProvider),

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -40,13 +40,14 @@ public class SecurityConfig {
 
             .and()
             .authorizeRequests()
-            .antMatchers("/tokens/**", "/test/**", "/hierarchy/**", "/role/**", "/court/**" ).permitAll()
-            .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()
-            .antMatchers(HttpMethod.POST, "/members/clients", "/members/employees").permitAll()
             .antMatchers(HttpMethod.POST, "/promotions/clients").hasRole("EMPLOYEE")
             .antMatchers(HttpMethod.GET, "/members/employees").hasRole("EMPLOYEE")
             .antMatchers(HttpMethod.POST, "/promotions/employees").hasRole("ADMIN")
-            .antMatchers(HttpMethod.PUT, "/employees/**").hasRole("ADMIN")
+            .antMatchers(HttpMethod.PUT, "/members/employees/**").hasRole("ADMIN")
+
+            .antMatchers("/tokens/**", "/test/**", "/hierarchy/**", "/role/**", "/court/**" ).permitAll()
+            .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()
+            .antMatchers(HttpMethod.POST, "/members/clients", "/members/employees").permitAll()
 
             .anyRequest().authenticated() //나머지 요청은 인증 필요
 

--- a/src/main/java/com/avg/lawsuitmanagement/common/custom/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/custom/CustomAccessDeniedHandler.java
@@ -1,0 +1,25 @@
+package com.avg.lawsuitmanagement.common.custom;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Autowired
+    @Qualifier("handlerExceptionResolver")
+    private HandlerExceptionResolver resolver;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException){
+
+        resolver.resolveException(request, response, null, accessDeniedException);
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
@@ -76,6 +77,26 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.BAD_CREDENTIAL;
         log.error(
             "BadCredentialsException 발생 : {} \n HttpStatus : {} \n Message : {} \n ExceptionDetail : {}",
+            errorCode.name(), errorCode.getHttpStatus().toString(),
+            errorCode.getMessage(), ex.toString());
+
+        return new ResponseEntity<>(
+            ExceptionDto.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build()
+            , errorCode.getHttpStatus()
+        );
+    }
+
+    /**
+     * 인가 관련 예외처리(권한 없을 시)
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ExceptionDto> accessDeniedException(AccessDeniedException ex) {
+        ErrorCode errorCode = ErrorCode.FORBIDDEN;
+        log.error(
+            "AccessDeniedException 발생 : {} \n HttpStatus : {} \n Message : {} \n ExceptionDetail : {}",
             errorCode.name(), errorCode.getHttpStatus().toString(),
             errorCode.getMessage(), ex.toString());
 

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
     //계정관련
     BAD_CREDENTIAL(HttpStatus.UNAUTHORIZED, "존재하지 않는 계정이거나 비밀번호가 틀렸습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     MEMBER_EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 
     //PROMOTION


### PR DESCRIPTION
Background
---
현재 인증/인가 중 인증에 대한 예외처리는 되어 있지만 인가에 대한 예외처리가 없다. 그래서 권한이 없을 경우(예를 들어 일반 유저가 관리자 권한이 필요한 작업을 하려고 할 경우), 제어되지 않는 에러가 발생하고 있다. 인가에 대한 적절한 예외처리를 해야한다.

Change
---
시큐리티에서 인가 예외를 처리하는 AccessDeniedHandler을 implements 하여 CustomAccessDeniedHandler 를 구현했다. AccessDeniedException 발생시 GlobalExceptionHandler로 토스하여 예외를 처리한다. 이 경우, **FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),** 예외를 발생시킨다.

Test
---
Postman을 통한 검증 완료