### PR TITLE
접수 및 일정 관리 수정

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/reception/service/ReceptionService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/reception/service/ReceptionService.java
@@ -49,6 +49,9 @@ public class ReceptionService {
     }
 
     public ReceptionDto edit(Long id, ReceptionEditForm form) {
+        if ("incomplete".equals(form.getStatus())) {
+            form.setReceivedAt(null);
+        }
         ReceptionUpdateParam param = form.toParam(id);
         receptionRepository.update(param);
         ReceptionDto result = receptionRepository.selectById(id);

--- a/src/main/java/com/avg/lawsuitmanagement/schedule/dto/ScheduleDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/schedule/dto/ScheduleDto.java
@@ -19,6 +19,7 @@ import lombok.ToString;
 public class ScheduleDto {
 
     private Long receptionId;
+    private Boolean receptionStatus;
     private LocalDate deadline;
     private Long lawsuitId;
     private String lawsuitType;

--- a/src/main/java/com/avg/lawsuitmanagement/schedule/service/ScheduleService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/schedule/service/ScheduleService.java
@@ -42,6 +42,7 @@ public class ScheduleService {
         List<ScheduleDto> result = rawDto.stream()
             .map(item -> ScheduleDto.builder()
                 .receptionId(item.getReceptionId())
+                .receptionStatus(item.getReceptionStatus())
                 .deadline(item.getDeadline())
                 .lawsuitId(item.getLawsuitId())
                 .lawsuitType(item.getLawsuitType())

--- a/src/main/resources/mybatis/mapper/Reception.xml
+++ b/src/main/resources/mybatis/mapper/Reception.xml
@@ -103,6 +103,8 @@
       parameterType="com.avg.lawsuitmanagement.reception.repository.param.ReceptionUpdateParam">
         UPDATE reception
         SET updated_at = now()
+        , received_at = #{receivedAt}
+          
         <if test="status != null">
             , status = #{status}
         </if>
@@ -111,9 +113,6 @@
         </if>
         <if test="contents != null">
             , contents = #{contents}
-        </if>
-        <if test="receivedAt != null">
-            , received_at = #{receivedAt}
         </if>
         <if test="deadline != null">
             , deadline = #{deadline}

--- a/src/main/resources/mybatis/mapper/Schedule.xml
+++ b/src/main/resources/mybatis/mapper/Schedule.xml
@@ -9,6 +9,7 @@
       resultType="com.avg.lawsuitmanagement.schedule.dto.ScheduleRawDto">
         SELECT r.id           `reception_id`,
                r.deadline     `deadline`,
+               r.status       `reception_status`,
                l.id           `lawsuit_id`,
                l.lawsuit_type `lawsuit_type`,
                l.name         `lawsuit_name`,


### PR DESCRIPTION
## Background

- 접수일과 마감일을 잘못 이해했기에 이를 수정하기 위함

## Change

- 접수일 -> 마감일 & 마감일 -> 완료일
- 접수 상태가 미완료일 경우, 완료일을 null으로 변환  
- GET /schedules 리턴 값에 receptionStatus 추가

## Test

- 프론트엔드 애플리케이션과 백엔드 애플리케이션의 연동을 통해 테스트 완료