### PR TITLE
Employee list

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortKey.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/type/MemberSortKey.java
@@ -10,7 +10,9 @@ public enum MemberSortKey {
     CREATED_AT("가입일", "created_at"),
     HIERARCHY("직급", "hierarchy_id"),
     ROLE("권한", "role_id"),
-    EMAIL("이메일", "email");
+    EMAIL("이메일", "email"),
+    NAME("이름", "name"),
+    PHONE("전화번호", "phone");
 
     private final String nameKr;
     private final String queryString;

--- a/src/main/resources/mybatis/mapper/Member.xml
+++ b/src/main/resources/mybatis/mapper/Member.xml
@@ -50,8 +50,7 @@
         <where>
             <if test="searchWord != null and searchWord != ''">
                 and (name like concat('%', #{searchWord}, '%')
-                or email like concat('%', #{searchWord}, '%')
-                or phone like concat('%', #{searchWord}, '%'))
+                or email like concat('%', #{searchWord}, '%'))
             </if>
 
             <if test="hierarchyId != 0">
@@ -109,8 +108,7 @@
         <where>
             <if test="searchWord != null and searchWord != ''">
                 and (name like concat('%', #{searchWord}, '%')
-                or email like concat('%', #{searchWord}, '%')
-                or phone like concat('%', #{searchWord}, '%'))
+                or email like concat('%', #{searchWord}, '%'))
             </if>
 
             <if test="hierarchyId != 0">


### PR DESCRIPTION
Background
---
1. 기존에는 사원 검색 시, 이름, 이메일, 전화번호로 동시 검색을 하고 있었다. 그러나 3가지를 동시 검색하니 검색 정확도가 지나치게 떨어져서, 불필요한 전화번호 검색을 없앨 필요가 있다.
2. 일관성을 위해 모든 컬럼 으로 정렬 가능하도록 해야 한다. 정렬 조건에 이름, 전화번호를 추가해야 한다.

Change
---
검색 쿼리에서 이메일 검색 제거
정렬 조건(Enum SortKey)에 이름, 전화번호 추가