### PR TITLE
[사건-사건리스트] 사건 상태별 정렬 BackEnd에서 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -2,9 +2,10 @@ package com.avg.lawsuitmanagement.lawsuit.controller;
 
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetEmployeeLawsuitForm;
-import com.avg.lawsuitmanagement.lawsuit.dto.GetLawsuitListDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.GetClientLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.GetEmployeeLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicDto;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import javax.validation.Valid;
@@ -29,7 +30,7 @@ public class LawsuitController {
 
     // 의뢰인 사건 리스트, 페이징 정보
     @GetMapping("/clients/{clientId}")
-    public ResponseEntity<GetLawsuitListDto> selectClientLawsuitList(
+    public ResponseEntity<GetClientLawsuitListDto> selectClientLawsuitList(
         @PathVariable("clientId") Long clientId, @ModelAttribute GetClientLawsuitForm form) {
 
         return ResponseEntity.ok(lawsuitService.selectClientLawsuitList(clientId, form));
@@ -37,7 +38,7 @@ public class LawsuitController {
 
     // 사원 별 사건 목록 조회
     @GetMapping("/employees/{employeeId}")
-    public ResponseEntity<GetLawsuitListDto> selectEmployeeLawsuitList(
+    public ResponseEntity<GetEmployeeLawsuitListDto> selectEmployeeLawsuitList(
         @PathVariable("employeeId") Long employeeId, @ModelAttribute GetEmployeeLawsuitForm form) {
         return ResponseEntity.ok(lawsuitService.selectEmployeeLawsuitList(employeeId, form));
     }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/form/GetClientLawsuitForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/form/GetClientLawsuitForm.java
@@ -1,5 +1,6 @@
 package com.avg.lawsuitmanagement.lawsuit.controller.form;
 
+import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,4 +10,5 @@ public class GetClientLawsuitForm {
     private Integer curPage;
     private Integer rowsPerPage;
     private String searchWord;
+    private LawsuitStatus lawsuitStatus;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/GetClientLawsuitListDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/GetClientLawsuitListDto.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-public class GetLawsuitListDto {
+public class GetClientLawsuitListDto {
     private List<LawsuitDto> lawsuitList;
-    private int count;
+    private LawsuitCountDto countDto;
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/GetEmployeeLawsuitListDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/GetEmployeeLawsuitListDto.java
@@ -1,0 +1,14 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class GetEmployeeLawsuitListDto {
+    private List<LawsuitDto> lawsuitList;
+    private int count;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitCountDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitCountDto.java
@@ -1,0 +1,15 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class LawsuitCountDto {
+    private int total;
+    private int registration;
+    private int proceeding;
+    private int closing;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.lawsuit.repository;
 
 import com.avg.lawsuitmanagement.lawsuit.dto.ClientLawsuitCountDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicRawDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitCountDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitClientMemberIdParam;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
@@ -16,8 +17,13 @@ import org.apache.ibatis.annotations.Mapper;
 public interface LawsuitMapperRepository {
 
     List<LawsuitDto> selectClientLawsuitList(SelectClientLawsuitListParam param);
+
+    LawsuitCountDto countLawsuitsStatusByClientId(SelectClientLawsuitListParam param);
+
     List<LawsuitDto> selectEmployeeLawsuitList(SelectEmployeeLawsuitListParam param);
-    int selectClientLawsuitCountBySearchWord(SelectClientLawsuitListParam param);
+
+    int selectClientLawsuitCountBySearchWordAndLawsuitStatus(SelectClientLawsuitListParam param);
+
     int selectEmployeeLawsuitCountBySearchWord(SelectEmployeeLawsuitListParam param);
 
     LawsuitDto selectLawsuitById(long lawsuitId);

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/SelectClientLawsuitListParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/param/SelectClientLawsuitListParam.java
@@ -1,6 +1,7 @@
 package com.avg.lawsuitmanagement.lawsuit.repository.param;
 
 import com.avg.lawsuitmanagement.common.util.dto.PagingDto;
+import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,14 +14,25 @@ public class SelectClientLawsuitListParam {
     private int offset;
     private int limit;
     private String searchWord;
+    private LawsuitStatus lawsuitStatus;
 
-
-    public static SelectClientLawsuitListParam of(long clientId, PagingDto pagingDto, String searchWord) {
+    public static SelectClientLawsuitListParam of(long clientId, PagingDto pagingDto, String searchWord, LawsuitStatus lawsuitStatus) {
         return SelectClientLawsuitListParam.builder()
             .clientId(clientId)
             .offset(pagingDto.getOffset())
             .limit(pagingDto.getLimit())
             .searchWord(searchWord)
+            .lawsuitStatus(lawsuitStatus)
+            .build();
+    }
+
+    public static SelectClientLawsuitListParam of(long clientId, String searchWord, LawsuitStatus lawsuitStatus) {
+        return SelectClientLawsuitListParam.builder()
+            .clientId(clientId)
+            .searchWord(searchWord)
+            .lawsuitStatus(lawsuitStatus)
+            .offset(0)
+            .limit(0)
             .build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/type/StringToLawsuitStatus.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/type/StringToLawsuitStatus.java
@@ -1,0 +1,17 @@
+package com.avg.lawsuitmanagement.lawsuit.type;
+
+import com.avg.lawsuitmanagement.member.type.MemberSortOrder;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+
+/***
+ * form에서 enum 값을 받아 올 때, 클라이언트에서 소문자 값이 와도 적절한 enum으로 컨버팅 하기 위한 컨버터
+ */
+@Component
+public class StringToLawsuitStatus implements Converter<String, LawsuitStatus> {
+    @Override
+    public LawsuitStatus convert(String input) {
+        return LawsuitStatus.valueOf(input.toUpperCase());
+    }
+}

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -18,9 +18,31 @@
             lawsuit_num like concat('%', #{searchWord}, '%')
             )
         </if>
+        <if test="lawsuitStatus != null">
+            and lawsuit_status = #{lawsuitStatus}
+        </if>
         order by l.created_at desc
         <if test="limit != 0 or offset != 0">
             limit #{limit} offset #{offset}
+        </if>
+    </select>
+
+    <select id="countLawsuitsStatusByClientId" parameterType="SelectClientLawsuitListParam" resultType="com.avg.lawsuitmanagement.lawsuit.dto.LawsuitCountDto">
+        select count(*) as total,
+        sum(case when `lawsuit_status` = 'REGISTRATION' then 1 else 0 end) as
+        registration,
+        sum(case when `lawsuit_status` = 'PROCEEDING' then 1 else 0 end) as proceeding,
+        sum(case when `lawsuit_status` = 'CLOSING' then 1 else 0 end) as closing
+        from `lawsuit`
+        where `id` in (select `lawsuit_id`
+                        from `lawsuit_client_map`
+                        where `client_id` = #{clientId})
+        and `is_deleted` = 0
+        <if test="searchWord != ''">
+            and (
+            name like concat('%', #{searchWord}, '%') or
+            lawsuit_num like concat('%', #{searchWord}, '%')
+            )
         </if>
     </select>
 
@@ -43,7 +65,7 @@
         </if>
     </select>
 
-    <select id="selectClientLawsuitCountBySearchWord" parameterType="SelectClientLawsuitListParam">
+    <select id="selectClientLawsuitCountBySearchWordAndLawsuitStatus" parameterType="SelectClientLawsuitListParam">
         select count(*)
         from lawsuit l
         join lawsuit_client_map map on l.id = map.lawsuit_id
@@ -54,6 +76,9 @@
             name like concat('%', #{searchWord}, '%') or
             lawsuit_num like concat('%', #{searchWord}, '%')
             )
+        </if>
+        <if test="lawsuitStatus != null">
+            and lawsuit_status = #{lawsuitStatus}
         </if>
     </select>
 
@@ -68,6 +93,9 @@
             name like concat('%', #{searchWord}, '%') or
             lawsuit_num like concat('%', #{searchWord}, '%')
             )
+        </if>
+        <if test="lawsuitStatus != null">
+            and lawsuit_status = #{lawsuitStatus}
         </if>
     </select>
 


### PR DESCRIPTION
Change
---
사건탭의 사건리스트에서 사건 상태별 정렬을 기존에는 FrontEnd에서 구현하였다.
이 기능을 BackEnd에서 구현하기 위해 사건 리스트를 조회하는 Controller에 사건 상태 값을 같이 전달하여
쿼리에서 조건에 따라 상태별 리스트와 개수를 받아오도록 하였다.

즉, 사건상태 버튼을 클릭할 때마다 request를 통해 해당 리스트와 개수를 받아오도록 하였다.

Test
---
프론트 연동 후 테스트 완료