### PR TITLE
PDF 출력을 위한 데이터를 가져올 기능을 추가

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -2,10 +2,11 @@ package com.avg.lawsuitmanagement.lawsuit.controller;
 
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetEmployeeLawsuitForm;
-import com.avg.lawsuitmanagement.lawsuit.dto.GetLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.GetLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitPrintResponseDto;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -67,6 +68,12 @@ public class LawsuitController {
     @GetMapping("/{lawsuitId}/basic")
     public ResponseEntity<?> getBasicLawsuitInfo(@PathVariable Long lawsuitId) {
         LawsuitBasicDto result = lawsuitService.getBasicLawsuitInfo(lawsuitId);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{lawsuitId}/print")
+    public ResponseEntity<?> getPrintLawsuitInfo(@PathVariable Long lawsuitId) {
+        LawsuitPrintResponseDto result = lawsuitService.getPrintInfo(lawsuitId);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitController.java
@@ -2,11 +2,10 @@ package com.avg.lawsuitmanagement.lawsuit.controller;
 
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetEmployeeLawsuitForm;
-import com.avg.lawsuitmanagement.lawsuit.dto.GetClientLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.GetClientLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.GetEmployeeLawsuitListDto;
-import com.avg.lawsuitmanagement.lawsuit.dto.GetLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitPrintResponseDto;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/IdNameDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/IdNameDto.java
@@ -1,0 +1,23 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class IdNameDto {
+
+    @EqualsAndHashCode.Include
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintAdviceDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintAdviceDto.java
@@ -1,0 +1,27 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LawsuitPrintAdviceDto {
+
+    private Long id;
+    private String title;
+    private String contents;
+    private LocalDate date;
+    private List<String> memberNames;
+    private List<String> clientNames;
+    
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintAdvicePreDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintAdvicePreDto.java
@@ -15,18 +15,13 @@ import lombok.ToString;
 @AllArgsConstructor
 @Builder
 @ToString
-public class LawsuitPrintLawsuitDto {
+public class LawsuitPrintAdvicePreDto {
 
     private Long id;
-    private String name;
-    private String num;
-    private String type;
-    private String court;
-    private Long commissionFee;
-    private Long contingentFee;
-    private String judgementResult;
-    private LocalDate judgementDate;
-    private List<String> clients;
-    private List<String> members;
+    private String title;
+    private String contents;
+    private LocalDate date;
+    private List<IdNameDto> memberIdNames;
+    private List<IdNameDto> clientIdNames;
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintExpenseDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintExpenseDto.java
@@ -1,0 +1,24 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LawsuitPrintExpenseDto {
+
+    private Long id;
+    private String contents;
+    private Long amount;
+    private LocalDate date;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintLawsuitDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintLawsuitDto.java
@@ -1,0 +1,28 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LawsuitPrintLawsuitDto {
+
+    private Long id;
+    private String name;
+    private String num;
+    private String court;
+    private Long commissionFee;
+    private Long contingentFee;
+    private String judgementResult;
+    private LocalDate judgementDate;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintRawDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintRawDto.java
@@ -19,9 +19,9 @@ public class LawsuitPrintRawDto {
     private Long lawsuitId;
     private String lawsuitName;
     private String lawsuitNum;
+    private String lawsuitType;
     private Long lawsuitCommissionFee;
     private Long lawsuitContingentFee;
-    private String lawsuitResult;
     private String lawsuitJudgementResult;
     private LocalDate lawsuitJudgementDate;
     private String courtName;

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintRawDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintRawDto.java
@@ -1,0 +1,41 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LawsuitPrintRawDto {
+
+    private Long lawsuitId;
+    private String lawsuitName;
+    private String lawsuitNum;
+    private Long lawsuitCommissionFee;
+    private Long lawsuitContingentFee;
+    private String lawsuitResult;
+    private String lawsuitJudgementResult;
+    private LocalDate lawsuitJudgementDate;
+    private String courtName;
+    private Long adviceId;
+    private String adviceTitle;
+    private String adviceContents;
+    private LocalDate adviceDate;
+    private Long memberId;
+    private String memberName;
+    private Long clientId;
+    private String clientName;
+    private Long expenseId;
+    private String expenseContents;
+    private Long expenseAmount;
+    private LocalDate expenseDate;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintResponseDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/LawsuitPrintResponseDto.java
@@ -1,0 +1,22 @@
+package com.avg.lawsuitmanagement.lawsuit.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LawsuitPrintResponseDto {
+
+    private LawsuitPrintLawsuitDto lawsuit;
+    private List<LawsuitPrintAdviceDto> advices;
+    private List<LawsuitPrintExpenseDto> expenses;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/repository/LawsuitMapperRepository.java
@@ -3,6 +3,7 @@ package com.avg.lawsuitmanagement.lawsuit.repository;
 import com.avg.lawsuitmanagement.lawsuit.dto.ClientLawsuitCountDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicRawDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitPrintRawDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitClientMemberIdParam;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.LawsuitStatusUpdateParam;
@@ -16,8 +17,11 @@ import org.apache.ibatis.annotations.Mapper;
 public interface LawsuitMapperRepository {
 
     List<LawsuitDto> selectClientLawsuitList(SelectClientLawsuitListParam param);
+
     List<LawsuitDto> selectEmployeeLawsuitList(SelectEmployeeLawsuitListParam param);
+
     int selectClientLawsuitCountBySearchWord(SelectClientLawsuitListParam param);
+
     int selectEmployeeLawsuitCountBySearchWord(SelectEmployeeLawsuitListParam param);
 
     LawsuitDto selectLawsuitById(long lawsuitId);
@@ -51,4 +55,6 @@ public interface LawsuitMapperRepository {
     List<LawsuitBasicRawDto> selectBasicLawInfo(Long lawsuitId);
 
     void updateLawsuitStatus(LawsuitStatusUpdateParam param);
+
+    List<LawsuitPrintRawDto> selectPrintInfo(Long lawsuitId);
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -20,7 +20,6 @@ import com.avg.lawsuitmanagement.lawsuit.dto.BasicLawsuitDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.BasicUserDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.GetClientLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.GetEmployeeLawsuitListDto;
-import com.avg.lawsuitmanagement.lawsuit.dto.GetLawsuitListDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.IdNameDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicRawDto;
@@ -43,6 +42,7 @@ import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDtoNonPass;
 import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +60,8 @@ public class LawsuitService {
     private final MemberMapperRepository memberMapperRepository;
     private final LawsuitMapperRepository lawsuitMapperRepository;
 
-    public GetClientLawsuitListDto selectClientLawsuitList(long clientId, GetClientLawsuitForm form) {
+    public GetClientLawsuitListDto selectClientLawsuitList(long clientId,
+        GetClientLawsuitForm form) {
         ClientDto clientDto = clientMapperRepository.selectClientById(clientId);
 
         // 해당 clientId의 의뢰인이 없을 경우

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -57,7 +57,8 @@
         </if>
     </select>
 
-    <select id="selectEmployeeLawsuitCountBySearchWord" parameterType="SelectEmployeeLawsuitListParam">
+    <select id="selectEmployeeLawsuitCountBySearchWord"
+      parameterType="SelectEmployeeLawsuitListParam">
         select count(*)
         from lawsuit l
         join lawsuit_member_map map on l.id = map.lawsuit_id
@@ -221,4 +222,38 @@
           AND l.id = #{id}
     </update>
 
+    <select id="selectPrintInfo"
+      parameterType="java.lang.Long"
+      resultType="com.avg.lawsuitmanagement.lawsuit.dto.LawsuitPrintRawDto">
+        SELECT l.id             `lawsuit_id`,
+               l.name           `lawsuit_name`,
+               l.lawsuit_num    `lawsuit_num`,
+               l.commission_fee `lawsuit_commission_fee`,
+               l.contingent_fee `lawsuit_contingent_fee`,
+               l.result         `lawsuit_judgement_result`,
+               l.judgement_date `lawsuit_judgement_date`,
+               co.name_kr       `court_name`,
+               a.id             `advice_id`,
+               a.title          `advice_title`,
+               a.contents       `advice_contents`,
+               a.adviced_at     `advice_date`,
+               m.id             `member_id`,
+               m.name           `member_name`,
+               c.id             `client_id`,
+               c.name           `client_name`,
+               e.id             `expense_id`,
+               e.contents       `expense_contents`,
+               e.amount         `expense_amount`,
+               e.spening_at     `expense_date`
+        FROM lawsuit l
+                 LEFT JOIN court co ON co.id = l.court_id
+                 LEFT JOIN expense e ON l.id = e.lawsuit_id
+                 LEFT JOIN advice a ON l.id = a.lawsuit_id
+                 LEFT JOIN advice_client_map ac ON a.id = ac.advice_id
+                 LEFT JOIN client c ON c.id = ac.client_id
+                 LEFT JOIN advice_member_map am ON a.id = am.advice_id
+                 LEFT JOIN member m ON m.id = am.member_id
+        WHERE l.is_deleted = 0
+          AND l.id = #{id}
+    </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -228,24 +228,27 @@
         SELECT l.id             `lawsuit_id`,
                l.name           `lawsuit_name`,
                l.lawsuit_num    `lawsuit_num`,
+               l.lawsuit_type   `lawsuit_type`,
                l.commission_fee `lawsuit_commission_fee`,
                l.contingent_fee `lawsuit_contingent_fee`,
                l.result         `lawsuit_judgement_result`,
                l.judgement_date `lawsuit_judgement_date`,
+               c.id             `client_id`,
+               c.name           `client_name`,
+               m.id             `member_id`,
+               m.name           `member_name`,
                co.name_kr       `court_name`,
                a.id             `advice_id`,
                a.title          `advice_title`,
                a.contents       `advice_contents`,
                a.adviced_at     `advice_date`,
-               m.id             `member_id`,
-               m.name           `member_name`,
-               c.id             `client_id`,
-               c.name           `client_name`,
                e.id             `expense_id`,
                e.contents       `expense_contents`,
                e.amount         `expense_amount`,
                e.spening_at     `expense_date`
         FROM lawsuit l
+                 LEFT JOIN lawsuit_client_map lc ON l.id = lc.lawsuit_id
+                 LEFT JOIN lawsuit_member_map lm ON l.id = lm.lawsuit_id
                  LEFT JOIN court co ON co.id = l.court_id
                  LEFT JOIN expense e ON l.id = e.lawsuit_id
                  LEFT JOIN advice a ON l.id = a.lawsuit_id


### PR DESCRIPTION
## Background

- 프론트엔드 애플리케이션 에서 PDF를 출력하기 위한 데이터(사건, 상담, 지출)를 가져오기 위함

## Change

- /lawsuit/{lawsuitId}/print 엔드포인트 추가

## Test

- 프론트엔드 애플리케이션과 백엔드 애플리케이션의 연동을 통해 테스트 완료