### PR TITLE
getLoginUserInfo 별도 서비스 분리

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
@@ -8,12 +8,14 @@ import com.avg.lawsuitmanagement.member.controller.form.SearchEmployeeListForm;
 import com.avg.lawsuitmanagement.member.dto.GetMemberListDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDtoNonPass;
+import com.avg.lawsuitmanagement.member.service.LoginUserInfoService;
 import com.avg.lawsuitmanagement.member.service.MemberService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -27,10 +29,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final LoginUserInfoService loginUserInfoService;
 
     @GetMapping("/me")
     public ResponseEntity<MemberDto> getLoginUserInfo() {
-        return ResponseEntity.ok(memberService.getLoginMemberInfo());
+        return ResponseEntity.ok(loginUserInfoService.getLoginMemberInfo());
     }
 
     @PutMapping("/me")
@@ -70,8 +73,15 @@ public class MemberController {
 
     @PutMapping("/employees/{employeeId}")
     public ResponseEntity<Void> updateEmployee(@PathVariable long employeeId, @RequestBody @Valid
-        MemberUpdateForm form) {
+    MemberUpdateForm form) {
         memberService.updateMemberInfo(employeeId, form);
         return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/employee/{employeeId}/lawsuit/{lawsuitId}")
+    public ResponseEntity<Void> deleteEmployeeFromLawsuit(@PathVariable long employeeId,
+        @PathVariable long lawsuitId) {
+
+        return null;
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/service/LoginUserInfoService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/LoginUserInfoService.java
@@ -1,0 +1,21 @@
+package com.avg.lawsuitmanagement.member.service;
+
+import com.avg.lawsuitmanagement.common.util.SecurityUtil;
+import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoginUserInfoService {
+
+    private final MemberMapperRepository memberMapperRepository;
+    public MemberDto getLoginMemberInfo() {
+        String email = SecurityUtil.getCurrentLoginEmail();
+        return memberMapperRepository.selectMemberByEmail(email);
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
@@ -9,7 +9,7 @@ import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.util.PagingUtil;
-import com.avg.lawsuitmanagement.common.util.SecurityUtil;
+import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import com.avg.lawsuitmanagement.member.controller.form.ClientSignUpForm;
 import com.avg.lawsuitmanagement.member.controller.form.EmployeeSignUpForm;
 import com.avg.lawsuitmanagement.member.controller.form.MemberUpdateForm;
@@ -41,14 +41,11 @@ public class MemberService {
     private final PromotionService promotionService;
     private final ClientMapperRepository clientMapperRepository;
     private final PasswordEncoder passwordEncoder;
-
-    public MemberDto getLoginMemberInfo() {
-        String email = SecurityUtil.getCurrentLoginEmail();
-        return memberMapperRepository.selectMemberByEmail(email);
-    }
+    private final LoginUserInfoService loginUserInfoService;
+    private final LawsuitService lawsuitService;
 
     public void updatePrivateInfo(PrivateUpdateForm form) {
-        MemberDto me = getLoginMemberInfo();
+        MemberDto me = loginUserInfoService.getLoginMemberInfo();
         memberMapperRepository.updateMember(UpdateMemberParam.of(form, me.getId()));
     }
 
@@ -118,6 +115,10 @@ public class MemberService {
             throw new CustomRuntimeException(MEMBER_NOT_FOUND);
         }
         memberMapperRepository.updateMember(UpdateMemberParam.of(form, id));
+    }
+
+    public void deleteEmployeeFromLawsuit(long employeeId, long lawsuitId) {
+        return;
     }
 
     private long insertMember(InsertMemberParam param) {

--- a/src/main/java/com/avg/lawsuitmanagement/reception/service/ReceptionService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/reception/service/ReceptionService.java
@@ -3,7 +3,7 @@ package com.avg.lawsuitmanagement.reception.service;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
-import com.avg.lawsuitmanagement.member.service.MemberService;
+import com.avg.lawsuitmanagement.member.service.LoginUserInfoService;
 import com.avg.lawsuitmanagement.reception.controller.form.ReceptionCreateForm;
 import com.avg.lawsuitmanagement.reception.controller.form.ReceptionEditForm;
 import com.avg.lawsuitmanagement.reception.controller.form.ReceptionSearchForm;
@@ -22,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReceptionService {
 
     private final ReceptionMapperRepository receptionRepository;
-    private final MemberService memberService;
     private final LawsuitService lawsuitService;
+    private final LoginUserInfoService loginUserInfoService;
 
     public List<ReceptionDto> search(ReceptionSearchForm form) {
         ReceptionSelectParam param = form.toParam();
@@ -39,7 +39,7 @@ public class ReceptionService {
 
     @Transactional
     public ReceptionDto create(ReceptionCreateForm form) {
-        MemberDto member = memberService.getLoginMemberInfo();
+        MemberDto member = loginUserInfoService.getLoginMemberInfo();
         ReceptionInsertParam param = form.toParam(member.getId());
         receptionRepository.insert(param);
         Long id = param.getId();

--- a/src/main/java/com/avg/lawsuitmanagement/schedule/service/ScheduleService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/schedule/service/ScheduleService.java
@@ -1,7 +1,7 @@
 package com.avg.lawsuitmanagement.schedule.service;
 
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
-import com.avg.lawsuitmanagement.member.service.MemberService;
+import com.avg.lawsuitmanagement.member.service.LoginUserInfoService;
 import com.avg.lawsuitmanagement.schedule.controller.form.ScheduleSearchForm;
 import com.avg.lawsuitmanagement.schedule.dto.ScheduleClientInfoDto;
 import com.avg.lawsuitmanagement.schedule.dto.ScheduleDto;
@@ -27,10 +27,10 @@ import org.springframework.stereotype.Service;
 public class ScheduleService {
 
     private final ScheduleMapperRepository scheduleRepository;
-    private final MemberService memberService;
+    private final LoginUserInfoService loginUserInfoService;
 
     public List<ScheduleDto> search(ScheduleSearchForm form) {
-        MemberDto member = memberService.getLoginMemberInfo();
+        MemberDto member = loginUserInfoService.getLoginMemberInfo();
         ScheduleSelectParam param = form.toParam(member.getId());
 
         List<ScheduleRawDto> rawDto = scheduleRepository.select(param);

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -94,9 +94,6 @@
             lawsuit_num like concat('%', #{searchWord}, '%')
             )
         </if>
-        <if test="lawsuitStatus != null">
-            and lawsuit_status = #{lawsuitStatus}
-        </if>
     </select>
 
     <select id="selectLawsuitById" parameterType="java.lang.Long">


### PR DESCRIPTION
Background
---
현재 로그인한 사용자의 정보를 불러오는 getLoginUserInfo는 다양한 서비스에서 사용된다. 그런데 여태까지 memberService에 해당 메소드가 있어서 순환참조 문제가 발생하곤 했다.

Change
---
로그인한 사용자의 정보를 위해 굳이 MemberService를 의존할 필요 없도록 getLoginUserInfo를 별도 서비스로 뺐다.