### PR TITLE
사건 담당자 제거 기능 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
             .antMatchers(HttpMethod.GET, "/members/employees").hasRole("EMPLOYEE")
             .antMatchers(HttpMethod.POST, "/promotions/employees").hasRole("ADMIN")
             .antMatchers(HttpMethod.PUT, "/members/employees/**").hasRole("ADMIN")
+            .antMatchers(HttpMethod.PATCH, "/members/employees/**").hasRole("ADMIN")
 
             .antMatchers("/tokens/**", "/test/**", "/hierarchy/**", "/role/**", "/court/**" ).permitAll()
             .antMatchers(HttpMethod.GET, "/promotions/clients", "/promotions/employees").permitAll()

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    
+
     //500 발생
     UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 예외가 발생했습니다."),
 
@@ -45,11 +45,11 @@ public enum ErrorCode {
     //사건 관련 예외
     LAWSUIT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사건입니다."),
     LAWSUIT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상태입니다."),
+    CANNOT_DELETE_SINGLE_EMPLOYEE_LAWSUIT(HttpStatus.BAD_REQUEST, "단일 담당자 사건은 삭제할 수 없습니다."),
 
 
     //상담 관련 예외
     ADVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상담입니다."),
-
 
 
     //직책, 역할, 법원

--- a/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/controller/MemberController.java
@@ -78,10 +78,10 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/employee/{employeeId}/lawsuit/{lawsuitId}")
+    @PatchMapping("/employees/{employeeId}/lawsuits/{lawsuitId}")
     public ResponseEntity<Void> deleteEmployeeFromLawsuit(@PathVariable long employeeId,
         @PathVariable long lawsuitId) {
-
-        return null;
+        memberService.deleteEmployeeFromLawsuit(employeeId, lawsuitId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.member.repository;
 
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
 import com.avg.lawsuitmanagement.member.dto.MemberDtoNonPass;
+import com.avg.lawsuitmanagement.member.repository.param.DeleteEmployeeFromLawsuitParam;
 import com.avg.lawsuitmanagement.member.repository.param.InsertMemberParam;
 import com.avg.lawsuitmanagement.member.repository.param.SearchEmployeeListParam;
 import com.avg.lawsuitmanagement.member.repository.param.UpdateMemberParam;
@@ -18,5 +19,6 @@ public interface MemberMapperRepository {
     List<MemberDtoNonPass> selectEmployeeListBySearchCondition(SearchEmployeeListParam param);
     int selectEmployeeListBySearchConditionCount(SearchEmployeeListParam param);
     MemberDtoNonPass selectMemberById(long employeeId);
+    void deleteEmployeeFromLawsuit(DeleteEmployeeFromLawsuitParam param);
 
 }

--- a/src/main/java/com/avg/lawsuitmanagement/member/repository/param/DeleteEmployeeFromLawsuitParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/repository/param/DeleteEmployeeFromLawsuitParam.java
@@ -1,0 +1,14 @@
+package com.avg.lawsuitmanagement.member.repository.param;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class DeleteEmployeeFromLawsuitParam {
+
+    private long employeeId;
+    private long lawsuitId;
+}

--- a/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
@@ -125,7 +125,7 @@ public class MemberService {
         LawsuitBasicDto basicLawsuitInfo = lawsuitService.getBasicLawsuitInfo(lawsuitId);
 
         List<BasicUserDto> employees = basicLawsuitInfo.getEmployees();
-        if (isEmployeeInLawsuit(employeeId, employees)) {
+        if (!isEmployeeInLawsuit(employeeId, employees)) {
             throw new CustomRuntimeException(ErrorCode.MEMBER_NOT_ASSIGNED_TO_LAWSUIT);
         }
 

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -41,7 +41,8 @@
         </if>
     </select>
 
-    <select id="countLawsuitsStatusByClientId" parameterType="SelectClientLawsuitListParam" resultType="com.avg.lawsuitmanagement.lawsuit.dto.LawsuitCountDto">
+    <select id="countLawsuitsStatusByClientId" parameterType="SelectClientLawsuitListParam"
+      resultType="com.avg.lawsuitmanagement.lawsuit.dto.LawsuitCountDto">
         select count(*) as total,
         sum(case when `lawsuit_status` = 'REGISTRATION' then 1 else 0 end) as
         registration,
@@ -49,8 +50,8 @@
         sum(case when `lawsuit_status` = 'CLOSING' then 1 else 0 end) as closing
         from `lawsuit`
         where `id` in (select `lawsuit_id`
-                        from `lawsuit_client_map`
-                        where `client_id` = #{clientId})
+        from `lawsuit_client_map`
+        where `client_id` = #{clientId})
         and `is_deleted` = 0
         <if test="searchWord != ''">
             and (
@@ -67,6 +68,7 @@
         join lawsuit_member_map map on l.id = map.lawsuit_id
         where map.member_id= #{memberId}
         and l.is_deleted = false
+        and map.is_deleted = false
         <if test="searchWord != ''">
             and (
             name like concat('%', #{searchWord}, '%') or
@@ -79,7 +81,8 @@
         </if>
     </select>
 
-    <select id="selectClientLawsuitCountBySearchWordAndLawsuitStatus" parameterType="SelectClientLawsuitListParam">
+    <select id="selectClientLawsuitCountBySearchWordAndLawsuitStatus"
+      parameterType="SelectClientLawsuitListParam">
         select count(*)
         from lawsuit l
         join lawsuit_client_map map on l.id = map.lawsuit_id
@@ -103,6 +106,7 @@
         join lawsuit_member_map map on l.id = map.lawsuit_id
         where map.member_id = #{memberId}
         and l.is_deleted = false
+        and map.is_deleted = false
         <if test="searchWord != ''">
             and (
             name like concat('%', #{searchWord}, '%') or

--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -254,6 +254,8 @@
                  LEFT JOIN lawsuit_client_map lc ON lc.lawsuit_id = l.id
                  LEFT JOIN client c ON lc.client_id = c.id
         WHERE l.is_deleted = 0
+          AND lm.is_deleted = 0
+          AND lc.is_deleted = 0
           AND l.id = #{lawsuitId};
     </select>
 

--- a/src/main/resources/mybatis/mapper/Member.xml
+++ b/src/main/resources/mybatis/mapper/Member.xml
@@ -126,4 +126,11 @@
         </where>
     </select>
 
+    <update id="deleteEmployeeFromLawsuit" parameterType="DeleteEmployeeFromLawsuitParam">
+        update lawsuit_member_map
+        set is_deleted = true
+        where lawsuit_id = #{lawsuitId}
+          and member_id = #{employeeId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
Change
---
사건에서 담당자를 제거하는 기능을 구현하였다.
조건1. 관리자만 가능하다.
조건2. 단일 담당자 사건일 경우 삭제 불가능하며, 예외 발생한다.
조건3. 타겟 담당자가 해당 사건의 담당자가 아닌지 체크한다.

Test
---
프론트 연동 후 테스트 완료