### PR TITLE
fix: 지출 수정시 사건 상태 '진행' 상태로 변경

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/expense/controller/ExpenseController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/expense/controller/ExpenseController.java
@@ -93,8 +93,8 @@ public class ExpenseController {
 
     // 지출 삭제
     @PatchMapping("/delete/{expenseId}")
-    public ResponseEntity<Void> deleteExpense(@PathVariable Long expenseId) {
-        expenseService.deleteExpense(expenseId);
+    public ResponseEntity<Void> deleteExpense(@PathVariable Long expenseId, @Validated @RequestParam long lawsuitId) {
+        expenseService.deleteExpense(expenseId, lawsuitId);
         return ResponseEntity.ok(null);
     }
 

--- a/src/main/java/com/avg/lawsuitmanagement/expense/controller/form/ExpenseUpdateForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/expense/controller/form/ExpenseUpdateForm.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 @Builder
 @ToString
 public class ExpenseUpdateForm {
+    private Long lawsuitId;
     private LocalDate speningAt;
     private String contents;
     private Long amount;

--- a/src/main/java/com/avg/lawsuitmanagement/expense/service/ExpenseService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/expense/service/ExpenseService.java
@@ -1,5 +1,6 @@
 package com.avg.lawsuitmanagement.expense.service;
 
+import com.avg.lawsuitmanagement.common.util.SecurityUtil;
 import com.avg.lawsuitmanagement.expense.controller.form.ExpenseInsertForm;
 import com.avg.lawsuitmanagement.expense.controller.form.ExpenseSearchForm;
 import com.avg.lawsuitmanagement.expense.controller.form.ExpenseUpdateForm;
@@ -8,15 +9,23 @@ import com.avg.lawsuitmanagement.expense.repository.ExpenseMapperRepository;
 import com.avg.lawsuitmanagement.expense.repository.param.ExpenseInsertParam;
 import com.avg.lawsuitmanagement.expense.repository.param.ExpenseSelectParam;
 import com.avg.lawsuitmanagement.expense.repository.param.ExpenseUpdateParam;
+import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
+import com.avg.lawsuitmanagement.lawsuit.type.LawsuitStatus;
+import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
+import com.avg.lawsuitmanagement.member.service.LoginUserInfoService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ExpenseService {
 
     private final ExpenseMapperRepository expenseRepository;
+    private final LawsuitService lawsuitService;
+    private final MemberMapperRepository memberMapperRepository;
+    private final LoginUserInfoService loginUserInfoService;
 
     public List<ExpenseDto> searchExpense(ExpenseSearchForm form) {
         return expenseRepository.selectSearchExpense(form.toParam());
@@ -28,17 +37,45 @@ public class ExpenseService {
         return expenseRepository.searchCount(param);
     }
 
+    @Transactional
     public void insertExpense(ExpenseInsertForm form) {
-        ExpenseInsertParam param = form.toParam();
-        expenseRepository.insertExpense(param);
+        // 기존에 등록된 멤버 id 리스트
+        List<Long> originMemberIdList = memberMapperRepository.selectMemberIdListByLawsuitId(form.getLawsuitId());
+
+        if (isUserAuthorizedForLawsuit(loginUserInfoService.getLoginMemberInfo().getId(), originMemberIdList)) {
+            ExpenseInsertParam param = form.toParam();
+
+            expenseRepository.insertExpense(param);
+            lawsuitService.updateStatus(form.getLawsuitId(), LawsuitStatus.PROCEEDING);
+        }
     }
 
     public ExpenseDto updateExpense(Long expenseId, ExpenseUpdateForm form) {
-        expenseRepository.updateExpense(ExpenseUpdateParam.of(expenseId, form));
+        // 기존에 등록된 멤버 id 리스트
+        List<Long> originMemberIdList = memberMapperRepository.selectMemberIdListByLawsuitId(form.getLawsuitId());
+
+        if (isUserAuthorizedForLawsuit(loginUserInfoService.getLoginMemberInfo().getId(), originMemberIdList)) {
+            expenseRepository.updateExpense(ExpenseUpdateParam.of(expenseId, form));
+        }
+
         return expenseRepository.selectExpenseById(expenseId);
     }
 
-    public void deleteExpense(Long expenseId) {
-        expenseRepository.deleteExpense(expenseId);
+    public void deleteExpense(Long expenseId, Long lawsuitId) {
+        // 기존에 등록된 멤버 id 리스트
+        List<Long> originMemberIdList = memberMapperRepository.selectMemberIdListByLawsuitId(lawsuitId);
+
+        if (isUserAuthorizedForLawsuit(loginUserInfoService.getLoginMemberInfo().getId(), originMemberIdList)) {
+            expenseRepository.deleteExpense(expenseId);
+        }
+    }
+
+    private boolean isUserAuthorizedForLawsuit(long userId, List<Long> memberIds) {
+        if (SecurityUtil.getCurrentLoginRoleList().contains("ROLE_ADMIN")) {
+            return true;
+        }
+
+        // 로그인한 사용자가 해당 사건의 담당자가 아니라면
+        return memberIds.contains(userId);
     }
 }


### PR DESCRIPTION
Background
---
'사건상세' 페이지에서 지출 정보를 등록하면 해당 사건의 상태가 '진행' 상태로 변경되어야 한다.

Change
---
지출 정보를 등록 및 수정할 때 관리자 또는 해당 사건의 담당자인지 권한 확인 기능 추가

해당 사건 상태가 '등록' 상태일 때, 해당 사건의 지출 정보를 등록하면 사건의 상태가 '진행' 상태로 변경되는 기능 추가

Exception
---
사용자가 관리자 또는 해당 사건의 담당자가 아니면 MEMBER_NOT_ASSIGNED_TO_LAWSUIT Exception 발생

Test
---
프론트 연동 후 테스트 완료