### PR TITLE
청구서 공유기능 구현

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitEmailController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitEmailController.java
@@ -1,5 +1,6 @@
 package com.avg.lawsuitmanagement.lawsuit.controller;
 
+import com.avg.lawsuitmanagement.lawsuit.controller.form.SendBillForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.SendLawsuitBookForm;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import javax.validation.Valid;
@@ -24,6 +25,14 @@ public class LawsuitEmailController {
         SendLawsuitBookForm form) {
 
         lawsuitService.saveAndSendLawsuitBook(form, lawsuitId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{lawsuitId}/bill")
+    public ResponseEntity<Void> sendBill(@PathVariable Long lawsuitId, @RequestBody @Valid
+        SendBillForm form) {
+
+        lawsuitService.saveAndSendBill(form, lawsuitId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitEmailController.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/LawsuitEmailController.java
@@ -18,7 +18,7 @@ public class LawsuitEmailController {
 
     private final LawsuitService lawsuitService;
 
-    @PostMapping("/{lawsuitId}/send-book")
+    @PostMapping("/{lawsuitId}/book")
     public ResponseEntity<Void> sendLawsuitBook(@PathVariable Long lawsuitId,
         @RequestBody @Valid
         SendLawsuitBookForm form) {

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/form/SendBillForm.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/controller/form/SendBillForm.java
@@ -1,0 +1,19 @@
+package com.avg.lawsuitmanagement.lawsuit.controller.form;
+
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Valid
+public class SendBillForm {
+    @NotNull
+    private List<String> toList;
+
+    @NotNull
+    private String pdfData;
+
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/mail/BillMailDto.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/dto/mail/BillMailDto.java
@@ -1,0 +1,32 @@
+package com.avg.lawsuitmanagement.lawsuit.dto.mail;
+
+import com.avg.lawsuitmanagement.lawsuit.controller.form.SendBillForm;
+import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class BillMailDto {
+
+    private List<String> toList;
+    private String fullFilePath;
+    private LawsuitDto lawsuitDto;
+
+    public static BillMailDto of(LawsuitDto lawsuitDto, String fullFilePath, SendBillForm form) {
+        return BillMailDto.builder()
+            .toList(form.getToList())
+            .lawsuitDto(lawsuitDto)
+            .fullFilePath(fullFilePath)
+            .build();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitMailService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitMailService.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.lawsuit.service;
 
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.common.exception.type.ErrorCode;
+import com.avg.lawsuitmanagement.lawsuit.dto.mail.BillMailDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.mail.LawsuitBookMailDto;
 import java.io.File;
 import javax.mail.internet.InternetAddress;
@@ -46,6 +47,42 @@ public class LawsuitMailService {
             text.append("<h2'> 사건번호 : ").append(dto.getLawsuitDto().getLawsuitNum())
                 .append("</h2>");
             text.append("해당 사건에 대한 사건집을 첨부합니다.").append("</br>").append("감사합니다.");
+            text.append("</div>");
+
+            helper.setText(text.toString(), true);
+
+            FileSystemResource file = new FileSystemResource(new File(dto.getFullFilePath()));
+            helper.addAttachment(file.getFilename(), file);
+
+            javaMailSender.send(mimeMessage);
+        } catch (Exception e) {
+            throw new CustomRuntimeException(ErrorCode.CANNOT_SEND_MAIL);
+        }
+    }
+
+    public void sendBill(BillMailDto dto) {
+
+        if(dto.getFullFilePath() == null || dto.getFullFilePath().isEmpty()) {
+            throw new CustomRuntimeException(ErrorCode.CANNOT_SEND_MAIL);
+        }
+
+        //메일 전송
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true);
+
+            helper.setTo(dto.getToList().toArray(new String[0]));
+            helper.setSubject("[더존 사건관리 서비스] " + dto.getLawsuitDto().getName() + " 사건의 청구서입니다.");
+            helper.setFrom(new InternetAddress(from, "더존 사건관리 서비스"));
+
+            StringBuilder text = new StringBuilder();
+            text.append("<div style='margin:100px;'>");
+            text.append("<div align='center' style='border:1px solid black; font-family:verdana';>");
+            text.append("<h2'> 사건명 : ").append(dto.getLawsuitDto().getName())
+                .append("</h2>");
+            text.append("<h2'> 사건번호 : ").append(dto.getLawsuitDto().getLawsuitNum())
+                .append("</h2>");
+            text.append("해당 사건에 대한 청구서를 첨부합니다.").append("</br>").append("감사합니다.");
             text.append("</div>");
 
             helper.setText(text.toString(), true);

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitService.java
@@ -17,6 +17,7 @@ import com.avg.lawsuitmanagement.file.service.FileService;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetClientLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.GetEmployeeLawsuitForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.InsertLawsuitForm;
+import com.avg.lawsuitmanagement.lawsuit.controller.form.SendBillForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.SendLawsuitBookForm;
 import com.avg.lawsuitmanagement.lawsuit.controller.form.UpdateLawsuitInfoForm;
 import com.avg.lawsuitmanagement.lawsuit.dto.BasicLawsuitDto;
@@ -27,6 +28,7 @@ import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitBasicRawDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitCountDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.LawsuitDto;
+import com.avg.lawsuitmanagement.lawsuit.dto.mail.BillMailDto;
 import com.avg.lawsuitmanagement.lawsuit.dto.mail.LawsuitBookMailDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository;
 import com.avg.lawsuitmanagement.lawsuit.repository.param.InsertLawsuitParam;
@@ -307,6 +309,26 @@ public class LawsuitService {
 
         //메일
         lawsuitMailService.sendLawsuitBook(LawsuitBookMailDto.of(lawsuitDto, fullFilePath, form));
+    }
+
+    public void saveAndSendBill(SendBillForm form, long lawsuitId) {
+
+        //사건 조회
+        LawsuitDto lawsuitDto = lawsuitMapperRepository.selectLawsuitById(lawsuitId);
+        if (lawsuitDto == null) {
+            throw new CustomRuntimeException(LAWSUIT_NOT_FOUND);
+        }
+        //저장
+        String fullFilePath = fileService.save(FileSaveDto.builder()
+            .data(form.getPdfData())
+            .extension("pdf")
+            .fileName(lawsuitDto.getLawsuitNum() + "청구서")
+            .detailPath("bill/")
+            .build()
+        );
+
+        //메일
+        lawsuitMailService.sendBill(BillMailDto.of(lawsuitDto, fullFilePath, form));
     }
 
     public void updateStatus(Long id, LawsuitStatus status) {


### PR DESCRIPTION
Background
---
청구서 공유 기능은 사건집 파일을 만들어서 이해당사자에게 메일로 보내는 기능이다.
pdf를 만들어내는 작업은 프론트에서 한다.
백에서는 사건집 pdf파일을 받아서 저장하고, 메일에 첨부하여 전송한다.

Change
---
청구서 저장 및 전송 기능 구현
상세 내용은 사건집 보내기와 같음

Test
---
프론트 연동 테스트 완료