### PR TITLE
사건수정 쿼리 버그 해결

### DIFF
--- a/src/main/resources/mybatis/mapper/Lawsuit.xml
+++ b/src/main/resources/mybatis/mapper/Lawsuit.xml
@@ -208,10 +208,13 @@
       parameterType="com.avg.lawsuitmanagement.lawsuit.repository.param.LawsuitClientMemberIdParam">
         update lawsuit_member_map
         set is_deleted = 0
-        where lawsuit_id = #{lawsuitId} and
-        <foreach item="memberId" collection="memberIdList" separator="or">
-            member_id = #{memberId}
-        </foreach>
+        where lawsuit_id = #{lawsuitId}
+        <if test="memberIdList != null and memberIdList.size() > 0">
+            and
+            <foreach item="memberId" collection="memberIdList" separator="or">
+                member_id = #{memberId}
+            </foreach>
+        </if>
     </update>
 
     <!-- 기존에 있던 담당자 id 삭제 -->
@@ -220,9 +223,13 @@
         update lawsuit_member_map
         set is_deleted = 1
         where lawsuit_id = #{lawsuitId}
-        <foreach item="memberId" collection="memberIdList" separator="AND">
-            and member_id = #{memberId}
-        </foreach>
+        <if test="memberIdList != null and memberIdList.size() > 0">
+            and
+            <foreach item="memberId" collection="memberIdList" separator="OR">
+                member_id = #{memberId}
+            </foreach>
+        </if>
+
     </update>
 
     <!-- 기존에 있던 의뢰인 id 삭제 -->
@@ -231,9 +238,12 @@
         update lawsuit_client_map
         set is_deleted = 1
         where lawsuit_id = #{lawsuitId}
-        <foreach item="clientId" collection="clientIdList" separator="AND">
-            and client_id = #{clientId}
-        </foreach>
+        <if test="clientIdList != null and clientIdList.size() > 0">
+            and
+            <foreach item="clientId" collection="clientIdList" separator="OR">
+                client_id = #{clientId}
+            </foreach>
+        </if>
     </update>
 
     <select id="selectLawsuitList">


### PR DESCRIPTION
Background
---
사건 수정 관련한 쿼리들에 forEach 구문을 사용할 때 버그가 있었다.
버그 1. forEach 위에 and가 있었는데, forEach를 한번도 안 도는 경우 문제 발생
버그 2. forEach 안에도 and가 있어서 쿼리에 and가 2번 연속 들어가는 경우 발생

Change
---
수정 완료

Test
---
프론트 연결 후 테스트 완료