### PR TITLE
의뢰인/회원 관련 예외처리 등 수정

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.client.repository;
 
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
+import com.avg.lawsuitmanagement.client.repository.param.ReRegisterClientParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientMemberIdParam;
 import java.util.List;
@@ -13,7 +14,9 @@ public interface ClientMapperRepository {
     ClientDto selectClientById(long clientId);
     ClientDto selectClientByMemberId(long memberId);
     ClientDto selectClientByEmail(String email);
+    ClientDto selectDeletedClientByEmail(String email);
     void insertClient(InsertClientParam param);
+    void reRegisterClient(ReRegisterClientParam param);
     void updateClientMemberId(UpdateClientMemberIdParam param);
     void updateClientInfo(UpdateClientInfoParam param);
     void deleteClientInfo(long clientId);

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/ClientMapperRepository.java
@@ -12,6 +12,7 @@ import org.apache.ibatis.annotations.Mapper;
 public interface ClientMapperRepository {
 
     ClientDto selectClientById(long clientId);
+    ClientDto selectClientByEmailContainDeleted(String email);
     ClientDto selectClientByMemberId(long memberId);
     ClientDto selectClientByEmail(String email);
     ClientDto selectDeletedClientByEmail(String email);

--- a/src/main/java/com/avg/lawsuitmanagement/client/repository/param/ReRegisterClientParam.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/repository/param/ReRegisterClientParam.java
@@ -1,0 +1,31 @@
+package com.avg.lawsuitmanagement.client.repository.param;
+
+import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ReRegisterClientParam {
+    private Long clientId;
+    private String email;
+    private String name;
+    private String phone;
+    private String address;
+    private String addressDetail;
+    private boolean isDeleted;
+
+    public static ReRegisterClientParam of(Long clientId, InsertClientForm form) {
+        return ReRegisterClientParam.builder()
+            .clientId(clientId)
+            .email(form.getEmail())
+            .name(form.getName())
+            .phone(form.getPhone())
+            .address(form.getAddress())
+            .addressDetail(form.getAddressDetail())
+            .isDeleted(false)
+            .build();
+    }
+}

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -1,7 +1,7 @@
 package com.avg.lawsuitmanagement.client.service;
 
-import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_ALREADY_EXIST;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_NOT_FOUND;
+import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.EMAIL_ALREADY_EXIST;
 
 import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
 import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
@@ -61,7 +61,7 @@ public class ClientService {
 
         // 이미 등록된 고객이면
         if (clientDto != null) {
-            throw new CustomRuntimeException(CLIENT_ALREADY_EXIST);
+            throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
 
         // 등록된 고객이 아니면 db 입력

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -14,6 +14,7 @@ import com.avg.lawsuitmanagement.lawsuit.dto.ClientLawsuitCountDto;
 import com.avg.lawsuitmanagement.lawsuit.repository.LawsuitMapperRepository;
 import com.avg.lawsuitmanagement.lawsuit.service.LawsuitService;
 import com.avg.lawsuitmanagement.member.dto.MemberDto;
+import com.avg.lawsuitmanagement.member.repository.MemberMapperRepository;
 import com.avg.lawsuitmanagement.member.service.LoginUserInfoService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClientService {
 
     private final ClientMapperRepository clientMapperRepository;
+    private final MemberMapperRepository memberMapperRepository;
     private final LawsuitMapperRepository lawsuitMapperRepository;
     private final LawsuitService lawsuitService;
     private final LoginUserInfoService loginUserInfoService;
@@ -57,15 +59,17 @@ public class ClientService {
     }
 
     public void insertClient(InsertClientForm form) {
-        ClientDto clientDto = clientMapperRepository.selectClientByEmail(form.getEmail());
+        checkEmailDuplicate(form.getEmail());
+        clientMapperRepository.insertClient(InsertClientParam.of(form));
+    }
 
-        // 이미 등록된 고객이면
-        if (clientDto != null) {
+    private void checkEmailDuplicate(String email) {
+        if (clientMapperRepository.selectClientByEmail(email) != null) {
             throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
-
-        // 등록된 고객이 아니면 db 입력
-        clientMapperRepository.insertClient(InsertClientParam.of(form));
+        if (memberMapperRepository.selectMemberByEmail(email) != null) {
+            throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
+        }
     }
 
     public void updateClientInfo(long clientId, UpdateClientInfoForm form) {

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -2,6 +2,7 @@ package com.avg.lawsuitmanagement.client.service;
 
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_NOT_FOUND;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.EMAIL_ALREADY_EXIST;
+import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.SIGNED_CLIENT_CANNOT_DELETE;
 
 import com.avg.lawsuitmanagement.client.controller.form.InsertClientForm;
 import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
@@ -101,6 +102,11 @@ public class ClientService {
             throw new CustomRuntimeException(CLIENT_NOT_FOUND);
         }
 
+        //회원가입 된 의뢰인일 경우
+        if(clientDto.getMemberId() == 0) {
+            throw new CustomRuntimeException(SIGNED_CLIENT_CANNOT_DELETE);
+        }
+
         clientMapperRepository.deleteClientInfo(clientId);
 
         // cliendId가 속한 사건별 사건id와 의뢰인 수
@@ -122,7 +128,6 @@ public class ClientService {
     }
 
     public ClientDto selectClientIdByEmail(String email) {
-        ClientDto clientDto = clientMapperRepository.selectClientByEmail(email);
-        return clientDto;
+        return clientMapperRepository.selectClientByEmail(email);
     }
 }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -8,6 +8,7 @@ import com.avg.lawsuitmanagement.client.controller.form.UpdateClientInfoForm;
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
 import com.avg.lawsuitmanagement.client.repository.ClientMapperRepository;
 import com.avg.lawsuitmanagement.client.repository.param.InsertClientParam;
+import com.avg.lawsuitmanagement.client.repository.param.ReRegisterClientParam;
 import com.avg.lawsuitmanagement.client.repository.param.UpdateClientInfoParam;
 import com.avg.lawsuitmanagement.common.custom.CustomRuntimeException;
 import com.avg.lawsuitmanagement.lawsuit.dto.ClientLawsuitCountDto;
@@ -59,6 +60,14 @@ public class ClientService {
     }
 
     public void insertClient(InsertClientForm form) {
+        //예전에 삭제된 메일이었을 경우
+        ClientDto deletedClientInfo = clientMapperRepository.selectDeletedClientByEmail(form.getEmail());
+        if(deletedClientInfo != null) {
+            clientMapperRepository.reRegisterClient(ReRegisterClientParam.of(
+                deletedClientInfo.getId(), form));
+            return;
+        }
+
         checkEmailDuplicate(form.getEmail());
         clientMapperRepository.insertClient(InsertClientParam.of(form));
     }

--- a/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/client/service/ClientService.java
@@ -74,10 +74,10 @@ public class ClientService {
     }
 
     private void checkEmailDuplicate(String email) {
-        if (clientMapperRepository.selectClientByEmail(email) != null) {
+        if (clientMapperRepository.selectClientByEmailContainDeleted(email) != null) {
             throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
-        if (memberMapperRepository.selectMemberByEmail(email) != null) {
+        if (memberMapperRepository.selectMemberByEmailContainDeleted(email) != null) {
             throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
     }

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     CLIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 의뢰인입니다."),
     CLIENT_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 등록된 의뢰인입니다."),
     CLIENT_NOT_FOUND_IN_LAWSUIT(HttpStatus.NOT_FOUND, "해당 사건에 존재하지 않는 의뢰인 입니다."),
+    SIGNED_CLIENT_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "회원가입한 의뢰인은 삭제할 수 없습니다."),
 
     //사원 관련 예외
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사원입니다."),

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     //계정관련
     BAD_CREDENTIAL(HttpStatus.UNAUTHORIZED, "존재하지 않는 계정이거나 비밀번호가 틀렸습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-    MEMBER_EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 
     //PROMOTION
     CLIENT_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 의뢰인입니다."),

--- a/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/exception/type/ErrorCode.java
@@ -75,6 +75,8 @@ public enum ErrorCode {
     CHAT_ADD_FRIEND_MY_SELF(HttpStatus.BAD_REQUEST, "자신은 친구로 등록할 수 없습니다."),
     CHAT_ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "이미 친구로 등록되어 있습니다."),
 
+    //DB
+    DUPLICATE_KEY(HttpStatus.CONFLICT, "중복된 데이터가 있습니다."),
     //TEST
     EXCEPTION_AOP_TEST(HttpStatus.BAD_REQUEST, "TEST : 테스트용 예외가 발생했습니다.");
 

--- a/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitMailService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/lawsuit/service/LawsuitMailService.java
@@ -36,7 +36,7 @@ public class LawsuitMailService {
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true);
 
             helper.setTo(dto.getToList().toArray(new String[0]));
-            helper.setSubject("[더존 사건관리 서비스] " + dto.getLawsuitDto().getName() + " 사건의 사건집 입니다.");
+            helper.setSubject("[더존 사건관리 서비스] <" + dto.getLawsuitDto().getName() + "> 사건 기록책 입니다.");
             helper.setFrom(new InternetAddress(from, "더존 사건관리 서비스"));
 
             StringBuilder text = new StringBuilder();
@@ -46,13 +46,14 @@ public class LawsuitMailService {
                 .append("</h2>");
             text.append("<h2'> 사건번호 : ").append(dto.getLawsuitDto().getLawsuitNum())
                 .append("</h2>");
-            text.append("해당 사건에 대한 사건집을 첨부합니다.").append("</br>").append("감사합니다.");
+            text.append("해당 사건에 대한 사건기록책을 첨부합니다.").append("</br>").append(" 감사합니다.");
             text.append("</div>");
 
             helper.setText(text.toString(), true);
 
             FileSystemResource file = new FileSystemResource(new File(dto.getFullFilePath()));
-            helper.addAttachment(file.getFilename(), file);
+            String attachFileName = "[" + dto.getLawsuitDto().getLawsuitNum() + "] 사건 기록책";
+            helper.addAttachment(attachFileName, file);
 
             javaMailSender.send(mimeMessage);
         } catch (Exception e) {
@@ -72,7 +73,7 @@ public class LawsuitMailService {
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true);
 
             helper.setTo(dto.getToList().toArray(new String[0]));
-            helper.setSubject("[더존 사건관리 서비스] " + dto.getLawsuitDto().getName() + " 사건의 청구서입니다.");
+            helper.setSubject("[더존 사건관리 서비스] <" + dto.getLawsuitDto().getName() + "> 사건의 청구서입니다.");
             helper.setFrom(new InternetAddress(from, "더존 사건관리 서비스"));
 
             StringBuilder text = new StringBuilder();
@@ -82,13 +83,14 @@ public class LawsuitMailService {
                 .append("</h2>");
             text.append("<h2'> 사건번호 : ").append(dto.getLawsuitDto().getLawsuitNum())
                 .append("</h2>");
-            text.append("해당 사건에 대한 청구서를 첨부합니다.").append("</br>").append("감사합니다.");
+            text.append("해당 사건에 대한 청구서를 첨부합니다.").append("</br>").append(" 감사합니다.");
             text.append("</div>");
 
             helper.setText(text.toString(), true);
 
             FileSystemResource file = new FileSystemResource(new File(dto.getFullFilePath()));
-            helper.addAttachment(file.getFilename(), file);
+            String attachFileName = "[" + dto.getLawsuitDto().getLawsuitNum() + "] 사건 청구서";
+            helper.addAttachment(attachFileName, file);
 
             javaMailSender.send(mimeMessage);
         } catch (Exception e) {

--- a/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/repository/MemberMapperRepository.java
@@ -13,6 +13,7 @@ import org.apache.ibatis.annotations.Mapper;
 public interface MemberMapperRepository {
 
     MemberDto selectMemberByEmail(String email);
+    MemberDto selectMemberByEmailContainDeleted(String email);
     void insertMember(InsertMemberParam param);
     List<MemberDto> selectMemberListById(List<Long> memberExistList);
     void updateMember(UpdateMemberParam param);

--- a/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.avg.lawsuitmanagement.member.service;
 
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.CLIENT_ALREADY_REGISTERED;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.LAWSUIT_NOT_FOUND;
-import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.MEMBER_EMAIL_ALREADY_EXIST;
+import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.EMAIL_ALREADY_EXIST;
 import static com.avg.lawsuitmanagement.common.exception.type.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.avg.lawsuitmanagement.client.dto.ClientDto;
@@ -161,7 +161,7 @@ public class MemberService {
         //이메일 중복체크
         MemberDto member = memberMapperRepository.selectMemberByEmail(param.getEmail());
         if (member != null) {
-            throw new CustomRuntimeException(MEMBER_EMAIL_ALREADY_EXIST);
+            throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
         memberMapperRepository.insertMember(param);
         return param.getId();

--- a/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
@@ -159,10 +159,13 @@ public class MemberService {
 
     private long insertMember(InsertMemberParam param) {
         //이메일 중복체크
-        MemberDto member = memberMapperRepository.selectMemberByEmail(param.getEmail());
-        if (member != null) {
+        if(memberMapperRepository.selectMemberByEmailContainDeleted(param.getEmail()) != null) {
             throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
+        if(clientMapperRepository.selectClientByEmailContainDeleted(param.getEmail()) != null) {
+            throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
+        }
+
         memberMapperRepository.insertMember(param);
         return param.getId();
     }

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -6,15 +6,51 @@
 <mapper namespace="com.avg.lawsuitmanagement.client.repository.ClientMapperRepository">
 
     <select id="selectClientById" parameterType="java.lang.Long">
-        select id, email, name, phone, address, address_detail, created_at, updated_at, is_deleted, member_id
+        select id,
+               email,
+               name,
+               phone,
+               address,
+               address_detail,
+               created_at,
+               updated_at,
+               is_deleted,
+               member_id
         from client
-        where id = #{clientId} and is_deleted = false;
+        where id = #{clientId}
+          and is_deleted = false;
     </select>
 
     <select id="selectClientByEmail" parameterType="java.lang.String">
-        select id, email, name, phone, address, address_detail, created_at, updated_at, is_deleted, member_id
+        select id,
+               email,
+               name,
+               phone,
+               address,
+               address_detail,
+               created_at,
+               updated_at,
+               is_deleted,
+               member_id
         from client
-        where email = #{email} and is_deleted = false;
+        where email = #{email}
+          and is_deleted = false;
+    </select>
+
+    <select id="selectDeletedClientByEmail" parameterType="java.lang.String">
+        select id,
+               email,
+               name,
+               phone,
+               address,
+               address_detail,
+               created_at,
+               updated_at,
+               is_deleted,
+               member_id
+        from client
+        where email = #{email}
+          and is_deleted = true;
     </select>
 
     <insert id="insertClient" parameterType="InsertClientParam">
@@ -30,7 +66,22 @@
 
     <update id="updateClientInfo" parameterType="UpdateClientInfoParam">
         update client
-        set email = #{email}, name = #{name}, phone = #{phone}, address = #{address} , address_detail = #{addressDetail}
+        set email          = #{email},
+            name           = #{name},
+            phone          = #{phone},
+            address        = #{address},
+            address_detail = #{addressDetail}
+        where id = #{clientId};
+    </update>
+
+    <update id="reRegisterClient" parameterType="ReRegisterClientParam">
+        update client
+        set email          = #{email},
+            name           = #{name},
+            phone          = #{phone},
+            address        = #{address},
+            address_detail = #{addressDetail},
+            is_deleted      = #{isDeleted}
         where id = #{clientId};
     </update>
 
@@ -41,13 +92,23 @@
     </update>
 
     <select id="selectClientList">
-        select id, email, name, phone, address, address_detail, created_at, updated_at, is_deleted, member_id
+        select id,
+               email,
+               name,
+               phone,
+               address,
+               address_detail,
+               created_at,
+               updated_at,
+               is_deleted,
+               member_id
         from client
         where is_deleted = false;
     </select>
 
     <select id="selectClientListById" parameterType="java.util.List">
-        select id, email, name, phone, address, address_detail, created_at, updated_at, is_deleted, member_id
+        select id, email, name, phone, address, address_detail, created_at, updated_at, is_deleted,
+        member_id
         from client
         where id in
         <foreach item="item" index="index" collection="list" open="(" separator="," close=")">
@@ -68,7 +129,16 @@
     </select>
 
     <select id="selectClientByMemberId" parameterType="java.lang.Long">
-        select id, email, name, phone, address, address_detail, created_at, updated_at, is_deleted, member_id
+        select id,
+               email,
+               name,
+               phone,
+               address,
+               address_detail,
+               created_at,
+               updated_at,
+               is_deleted,
+               member_id
         from client
         where member_id = #{memberId};
     </select>

--- a/src/main/resources/mybatis/mapper/Client.xml
+++ b/src/main/resources/mybatis/mapper/Client.xml
@@ -5,6 +5,21 @@
 
 <mapper namespace="com.avg.lawsuitmanagement.client.repository.ClientMapperRepository">
 
+    <select id="selectClientByEmailContainDeleted" parameterType="java.lang.String">
+        select id,
+               email,
+               name,
+               phone,
+               address,
+               address_detail,
+               created_at,
+               updated_at,
+               is_deleted,
+               member_id
+        from client
+        where email = #{email}
+    </select>
+
     <select id="selectClientById" parameterType="java.lang.Long">
         select id,
                email,

--- a/src/main/resources/mybatis/mapper/Member.xml
+++ b/src/main/resources/mybatis/mapper/Member.xml
@@ -12,6 +12,12 @@
           and m.is_deleted = false
     </select>
 
+    <select id="selectMemberByEmailContainDeleted" parameterType="java.lang.String" resultType="MemberDto">
+        select id, email, password, name, hierarchy_id, phone, address, address_detail, role_id, created_at, updated_at, is_deleted
+        from member m
+        where m.email = #{email}
+    </select>
+
     <insert id="insertMember" parameterType="InsertMemberParam">
         insert into member (email, password, name, phone, hierarchy_id, address, address_detail,
         role_id)

--- a/src/test/java/com/avg/lawsuitmanagement/member/MemberServiceTest.java
+++ b/src/test/java/com/avg/lawsuitmanagement/member/MemberServiceTest.java
@@ -184,7 +184,7 @@ public class MemberServiceTest {
                 .build()));
 
         //then
-        assertEquals(ErrorCode.MEMBER_EMAIL_ALREADY_EXIST, exception.getErrorCode());
+        assertEquals(ErrorCode.EMAIL_ALREADY_EXIST, exception.getErrorCode());
     }
 
     private long insertClientAndGetClientId(InsertClientParam param) {


### PR DESCRIPTION
Change
---
1. 의뢰인 등록 / 직원 가입 시 email은 서로 중복될 수 없게 변경
2. 의뢰인 등록 시 예전에 삭제된 메일이었을 경우 update 하도록 변경 (어썰트 개념)
3. 의뢰인 등록/직원 가입 시 이메일 중복 검사를 할 때,  soft delete 된 메일도 중복 금지
4. 이미 회원가입된 의뢰인은 삭제할 수 없도록 예외처리
5. 청구서/기록책 전송 시 첨부파일 명을 정상적으로 보이도록 수정
6. DB 유니크 키 규칙 위반 시 GlobalExcepHandler에서 전역적으로 예외를 처리 하게 변경
 - 409와 함께 다음과 같은 예외 message가 전송된다. -> ex) 중복된 데이터가 있습니다. 중복된 데이터 : "형-001"

Test
---
프론트 연결 후 테스트 완료