### PR TITLE
고객 회원가입 시 항상 오류 뜨던 버그 수정

### DIFF
--- a/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
+++ b/src/main/java/com/avg/lawsuitmanagement/member/service/MemberService.java
@@ -67,7 +67,7 @@ public class MemberService {
         promotionService.deactivateClientPromotion(form.getPromotionKey());
 
         //3. 회원 테이블 - 삽입
-        long memberId = insertMember(InsertMemberParam.of(form, passwordEncoder));
+        long memberId = insertClient(InsertMemberParam.of(form, passwordEncoder));
 
         //4. 의뢰인 테이블 - 회원 id 갱신
         clientMapperRepository.updateClientMemberId(UpdateClientMemberIdParam.builder()
@@ -83,7 +83,7 @@ public class MemberService {
         //2. 키 비활성화
         promotionService.deactivateEmployeePromotion(form.getPromotionKey());
         //3. 데이터 삽입
-        insertMember(InsertMemberParam.of(form, passwordEncoder));
+        insertEmployee(InsertMemberParam.of(form, passwordEncoder));
     }
 
     @Transactional
@@ -157,12 +157,22 @@ public class MemberService {
         return memberMapperRepository.selectMemberIdListByLawsuitId(lawsuitId);
     }
 
-    private long insertMember(InsertMemberParam param) {
+    private long insertEmployee(InsertMemberParam param) {
         //이메일 중복체크
         if(memberMapperRepository.selectMemberByEmailContainDeleted(param.getEmail()) != null) {
             throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
         if(clientMapperRepository.selectClientByEmailContainDeleted(param.getEmail()) != null) {
+            throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
+        }
+
+        memberMapperRepository.insertMember(param);
+        return param.getId();
+    }
+
+    private long insertClient(InsertMemberParam param) {
+        //이메일 중복체크
+        if(memberMapperRepository.selectMemberByEmailContainDeleted(param.getEmail()) != null) {
             throw new CustomRuntimeException(EMAIL_ALREADY_EXIST);
         }
 


### PR DESCRIPTION
Background & Change
---
고객 회원가입 중복검사를 할때 client의 이메일과도 중복을 확인하고 있었다.
그러나 고객 회원가입 시 항상 client에 등록되어 있는 상태일 것이므로, 항상 오류가 발생했다
해당 로직을 제거했다.
