### PR TITLE
jasypt를 사용한 비밀키 암호화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     //file
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
+    //jasypt 비밀키 암호화
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/avg/lawsuitmanagement/common/config/JasyptConfig.java
+++ b/src/main/java/com/avg/lawsuitmanagement/common/config/JasyptConfig.java
@@ -1,0 +1,35 @@
+package com.avg.lawsuitmanagement.common.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * DB 비밀번호 등 비밀키를 암호화 하기 위한 config 입니다.
+ * 아래 사이트에서 암호화, 복호화 가능합니다.
+ * https://www.devglan.com/online-tools/jasypt-online-encryption-decryption
+ * 복호화 하기위해서는 JASYPT_SECRET_KEY가 필요하며, 환경변수로 입력해 줘야 합니다.
+ * 따라서 JASYPT_SECRET_KEY는 별도 채널로 관리하여야 합니다.
+ */
+@Configuration
+public class JasyptConfig {
+
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(System.getenv("JASYPT_SECRET_KEY"));
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,24 +1,39 @@
-spring.profiles.include=database
 #mybatis
 mybatis.type-aliases-package=com.avg.lawsuitmanagement
 mybatis.mapper-locations=classpath:mybatis/mapper/*.xml
 mybatis.configuration.map-underscore-to-camel-case=true
+
 #logging
-# JDBC ????? ??? ????? ?? ?? X
 logging.level.jdbc.audit=OFF
-# ResultSet? ??? ?? JDBC ?? ??? ??
 logging.level.jdbc.resultset=OFF
-# SQL ?? ??? Table???? ??
 logging.level.jdbc.resultsettable=INFO
-# SQL? ??? ??
 logging.level.jdbc.sqlonly=OFF
-# SQL + ???? ??
 logging.level.jdbc.sqltiming=INFO
-# ??? ??/?? ?? ??
 logging.level.jdbc.connection=OFF
-# Other settings
 logging.level.com.zaxxer.hikari=INFO
 logging.level.javax.sql.DataSource=OFF
 # Socket.io
 socket.host=0.0.0.0
 socket.port=7777
+
+# MySql
+spring.datasource.url=jdbc:log4jdbc:mysql://lawsuit-management-instance.cklf3l4rcuqo.ap-northeast-2.rds.amazonaws.com:3306/lawsuit-management?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
+spring.datasource.username=ENC(uUrLJE0x20tsRgBJZ4zJsg==)
+spring.datasource.password=ENC(0n2ACvjVg9ZGZKju1jt/7pJIHsnoJJgx)
+spring.datasource.driver-class-name= net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+
+#secretKey
+jwt.secret = ENC(A14F43CXYY0MBD3bYpqIJDuEpVn1sQNbWj3+cvAXy9qAoZTrXlfyumyTcnOhPFzuIAhD9BxxkA4xSeqSuugJe2zA9px+BzQc)
+
+#SMTP
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=ENC(vLDap5nJGAYqU6J1LJjWaD8Y+6gOGVP2mRyvNSQdju4=)
+spring.mail.password=ENC(6VcKmc/tMbGc3zIWuU9Y7eGaHNuSLcClcByTeK8VH0M=)
+
+#Optional
+spring.mail.properties.mail.debug= true
+spring.mail.properties.mail.smtp.connectiontimeout = 5000
+spring.mail.properties.mail.smtp.starttls.enable = true
+spring.mail.properties.mail.smtp.starttls.required = true
+spring.mail.properties.mail.smtp.auth=false


### PR DESCRIPTION
Background
---
서버정보 등 민감한 비밀키를 안전하고 편리하게 관리하기 위해 jasypt 모듈을 사용하여 암호화 하였습니다.

Change
---
비밀키는 암호화되었습니다. 따라서 기존 gitignore로 관리하던 database.properties를 삭제하고, application.properties에 암호화해서 저장했습니다.

Test
---
실행 테스트 완료

Analatics
---
아래 사이트에서 암호화와 복호화를 할 수 있습니다.
https://www.devglan.com/online-tools/jasypt-online-encryption-decryption
.yml 파일에는 ENC(암호화된 문자열) 형식으로 값을 입력하면 됩니다. 
또한 복호화를 위해서는 환경변수로 암호화에 사용된 비밀키를 입력해줘야 합니다.
인텔리제이에서 실행하려면 실행구성에 환경변수로 JASYPT_SECRET_KEY=암호 라고 입력하시면 됩니다. 
JASYPT_SECRET_KEY는 별도 채널로 공유하겠습니다.

Discuss
---
JASYPT_SECRET_KEY가 유출되면 모든 정보가 위험해집니다. 각별히 관리하여야 할 것 같습니다.